### PR TITLE
remove runasnonroot attribute from manifests

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,8 +21,6 @@ spec:
     spec:
       serviceAccountName: tekton-tasks-operator
       priorityClassName: system-cluster-critical
-      securityContext:
-        runAsNonRoot: true
       containers:
       - command:
         - /manager

--- a/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
@@ -260,8 +260,6 @@ spec:
                 securityContext:
                   allowPrivilegeEscalation: false
               priorityClassName: system-cluster-critical
-              securityContext:
-                runAsNonRoot: true
               serviceAccountName: tekton-tasks-operator
               terminationGracePeriodSeconds: 10
       permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:
remove runasnonroot attribute from manifests
in kubernetes cluster tto refused to start due to runasnonroot
attribute.

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
