### PR TITLE
reenque another reconciliation, when conflict cr occures

### DIFF
--- a/controllers/tektontasks_controller.go
+++ b/controllers/tektontasks_controller.go
@@ -145,7 +145,7 @@ func (r *tektonTasksReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	tektonRequest.Logger.V(1).Info("Updating CR status prior to operand reconciliation...")
 	err = preUpdateStatus(tektonRequest)
 	if err != nil {
-		return ctrl.Result{}, err
+		return handleError(tektonRequest, err)
 	}
 	tektonRequest.Logger.V(1).Info("CR status updated")
 
@@ -164,7 +164,7 @@ func (r *tektonTasksReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	tektonRequest.Logger.V(1).Info("Updating CR status post reconciliation...")
 	err = updateStatus(tektonRequest, reconcileResults)
 	if err != nil {
-		return ctrl.Result{}, err
+		return handleError(tektonRequest, err)
 	}
 	tektonRequest.Logger.Info("CR status updated")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
reenque another reconciliation, when conflict cr occures
this pr changes behaviour when there is an conflict err during cr
update. If there is conflict, reenque new reconciliation cycle
**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
