### PR TITLE
fix deletion of resources, when TTO CR is deleted

### DIFF
--- a/pkg/tekton-pipelines/tekton-pipelines.go
+++ b/pkg/tekton-pipelines/tekton-pipelines.go
@@ -84,10 +84,12 @@ func (t *tektonPipelines) Reconcile(request *common.Request) ([]common.Reconcile
 func (t *tektonPipelines) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
 	var objects []client.Object
 	for _, p := range t.pipelines {
-		objects = append(objects, &p)
+		o := p.DeepCopy()
+		objects = append(objects, o)
 	}
 	for _, cm := range t.configMaps {
-		objects = append(objects, &cm)
+		o := cm.DeepCopy()
+		objects = append(objects, o)
 	}
 
 	return common.DeleteAll(request, objects...)

--- a/pkg/tekton-tasks/tekton-tasks.go
+++ b/pkg/tekton-tasks/tekton-tasks.go
@@ -160,16 +160,20 @@ func (t *tektonTasks) Reconcile(request *common.Request) ([]common.ReconcileResu
 func (t *tektonTasks) Cleanup(request *common.Request) ([]common.CleanupResult, error) {
 	var objects []client.Object
 	for _, ct := range t.clusterTasks {
-		objects = append(objects, &ct)
+		o := ct.DeepCopy()
+		objects = append(objects, o)
 	}
 	for _, cr := range t.clusterRoles {
-		objects = append(objects, &cr)
+		o := cr.DeepCopy()
+		objects = append(objects, o)
 	}
 	for _, rb := range t.roleBindings {
-		objects = append(objects, &rb)
+		o := rb.DeepCopy()
+		objects = append(objects, o)
 	}
 	for _, sa := range t.serviceAccounts {
-		objects = append(objects, &sa)
+		o := sa.DeepCopy()
+		objects = append(objects, o)
 	}
 	return common.DeleteAll(request, objects...)
 }

--- a/tests/tekton-pipelines_test.go
+++ b/tests/tekton-pipelines_test.go
@@ -38,4 +38,28 @@ var _ = Describe("Tekton-pipelines", func() {
 			}
 		})
 	})
+
+	Context("resource deletion when CR is deleted", func() {
+		BeforeEach(func() {
+			tto := strategy.GetTTO()
+			apiClient.Delete(ctx, tto)
+		})
+
+		AfterEach(func() {
+			strategy.CreateTTOIfNeeded()
+		})
+
+		It("[test_id:TODO]operator should delete pipelines", func() {
+			livePipelines := &pipeline.PipelineList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, livePipelines,
+					client.MatchingLabels{
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(livePipelines.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no pipelines left")
+		})
+	})
 })

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -108,4 +108,68 @@ var _ = Describe("Tekton-tasks", func() {
 			}
 		})
 	})
+
+	Context("resource deletion when CR is deleted", func() {
+		BeforeEach(func() {
+			tto := strategy.GetTTO()
+			apiClient.Delete(ctx, tto)
+		})
+
+		AfterEach(func() {
+			strategy.CreateTTOIfNeeded()
+		})
+
+		It("[test_id:TODO]operator should delete tekton-tasks", func() {
+			liveTasks := &pipeline.ClusterTaskList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveTasks,
+					client.MatchingLabels{
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveTasks.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no cluster tasks left")
+		})
+
+		It("[test_id:TODO]operator should delete service accounts", func() {
+			liveSA := &v1.ServiceAccountList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveSA,
+					client.MatchingLabels{
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveSA.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no service accounts left")
+		})
+
+		It("[test_id:TODO]operator should delete cluster role", func() {
+			liveCR := &rbac.ClusterRoleList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveCR,
+					client.MatchingLabels{
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveCR.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no cluster roles left")
+
+		})
+
+		It("[test_id:TODO]operator should delete role bindings", func() {
+			liveRB := &rbac.RoleBindingList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveRB,
+					client.MatchingLabels{
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveRB.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no role bindings left")
+		})
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
fix deletion of resources, when TTO CR is deleted

During deletion of resources when TTO CR was deleted,
was deleted only one last item from slice. It was caused by fact,
that there was always appended adress of a single item, so in the end,
the slice was full of adresses to a single item.

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>

