### PR TITLE
Remove 'oc new-project tekton-pipelines' from deployment script

### DIFF
--- a/scripts/deploy-resources.sh
+++ b/scripts/deploy-resources.sh
@@ -9,15 +9,17 @@ fi
 KUBEVIRT_VERSION=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
 CDI_VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
 
+TEKTON_VERSION=$(curl -s https://api.github.com/repos/tektoncd/operator/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+
 if oc get templates > /dev/null 2>&1; then
   # Prepare Tekton Pipelines
-  oc new-project tekton-pipelines
   oc adm policy add-scc-to-user anyuid -z tekton-pipelines-controller
   oc adm policy add-scc-to-user anyuid -z tekton-pipelines-webhook
 fi
 
 # Deploy Tekton Pipelines
-oc apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
+oc apply -f "https://github.com/tektoncd/operator/releases/download/${TEKTON_VERSION}/openshift-release.yaml"
 
 # Deploy Kubevirt
 oc apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
@@ -32,8 +34,8 @@ oc apply -f "https://github.com/kubevirt/containerized-data-importer/releases/do
 oc apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-cr.yaml"
 
 # wait for tekton pipelines
-oc rollout status -n tekton-pipelines deployment/tekton-pipelines-controller --timeout 10m
-oc rollout status -n tekton-pipelines deployment/tekton-pipelines-webhook --timeout 10m
+oc rollout status -n openshift-pipelines deployment/tekton-pipelines-controller --timeout 10m
+oc rollout status -n openshift-pipelines deployment/tekton-pipelines-webhook --timeout 10m
 
 # Wait for kubevirt to be available
 oc rollout status -n cdi deployment/cdi-operator --timeout 10m


### PR DESCRIPTION
**What this PR does / why we need it**:
To stop this command causing errors in CI tests.
```
+ oc new-project tekton-pipelines
Error from server (Forbidden): You may not request a new project via this API.
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"k8s.io/test-infra/prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2022-04-25T09:51:29Z"}
error: failed to execute wrapped command: exit status 1
}
```
**Release note**:
```NONE

```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>