### PR TITLE
add ci builder image

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,0 +1,16 @@
+# This Dockerfile is used in openshift CI
+FROM quay.io/fedora/fedora:latest
+
+# Install dependencies and tools
+RUN dnf install -y jq 
+
+# Allow writes to /etc/passwd so a user for ansible can be added by CI commands
+RUN chmod a+w /etc/passwd
+
+# Create ansible tmp folder and set permissions
+RUN mkdir -p /.ansible/tmp && \
+    chmod -R 777 /.ansible
+
+# Download latest stable oc client binary
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \
+    chmod +x /usr/local/bin/oc


### PR DESCRIPTION
**What this PR does / why we need it**:
add ci builder image
this image will be used as a base image for openshift ci infrastructure
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
