### PR TITLE
don't generate manifest during functests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ unittest: fmt vet
 	go test -v -coverprofile cover.out $(SRC_PATHS_TESTS)
 	cd api && go test -v ./...
 
-functest: generate fmt vet manifests
+functest: fmt vet
 	go test -v -coverprofile cover.out -timeout 0 ./tests/...
 
 .PHONY: manifests

--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -x
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools
-RUN dnf install -y jq git make findutils which  && dnf clean all
+RUN dnf install -y jq git make findutils which gcc && dnf clean all
 
 # Download latest stable oc client binary
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -C /usr/local/bin -xzf - oc && \


### PR DESCRIPTION
**What this PR does / why we need it**:
don't generate manifest during functests
add gcc package to ci builder image

**Release note**:
```
NONE
```
