### PR TITLE
add rest of the tasks to TTO

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,7 @@ spec:
           - name: "DISK_VIRT_SYSPREP_IMG"
           - name: "MODIFY_VM_TEMPLATE_IMG"
           - name: "WAIT_FOR_VMI_STATUS_IMG"
+          - name: "GENERATE_SSH_KEYS_IMG"
           - name: "OPERATOR_NAMESPACE"
             valueFrom:
               fieldRef:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,12 +6,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - create
-- apiGroups:
   - '*'
   resources:
   - configmaps
@@ -24,6 +18,18 @@ rules:
   - '*'
   resources:
   - persistentvolumeclaims
+  verbs:
+  - '*'
+- apiGroups:
+  - '*'
+  resources:
+  - pods
+  verbs:
+  - create
+- apiGroups:
+  - '*'
+  resources:
+  - secrets
   verbs:
   - '*'
 - apiGroups:

--- a/controllers/tektontasks_controller.go
+++ b/controllers/tektontasks_controller.go
@@ -119,7 +119,7 @@ func (r *tektonTasksReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if updated, err := updateTektonTasks(tektonRequest); updated || (err != nil) {
 		// tekton was updated, and the update will trigger reconciliation again.
-		return ctrl.Result{}, err
+		return handleError(tektonRequest, err)
 	}
 
 	if isBeingDeleted(tektonRequest.Instance) {

--- a/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
@@ -63,6 +63,18 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - '*'
+          resources:
+          - pods
+          verbs:
+          - create
+        - apiGroups:
+          - '*'
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
@@ -198,6 +210,7 @@ spec:
           - get
           - list
           - patch
+          - update
           - watch
         serviceAccountName: tekton-tasks-operator
       deployments:
@@ -232,6 +245,7 @@ spec:
                 - name: DISK_VIRT_SYSPREP_IMG
                 - name: MODIFY_VM_TEMPLATE_IMG
                 - name: WAIT_FOR_VMI_STATUS_IMG
+                - name: GENERATE_SSH_KEYS_IMG
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -32,6 +32,7 @@ const (
 	DiskVirtSysprepImageKey   = "DISK_VIRT_SYSPREP_IMG"
 	ModifyVMTemplateImageKey  = "MODIFY_VM_TEMPLATE_IMG"
 	WaitForVMISTatusImageKey  = "WAIT_FOR_VMI_STATUS_IMG"
+	GenerateSSHKeysImageKey   = "GENERATE_SSH_KEYS_IMG"
 
 	DefaultWaitForVMIStatusIMG  = "quay.io/kubevirt/tekton-task-wait-for-vmi-status:" + operands.TektonTasksVersion
 	DeafultModifyVMTemplateIMG  = "quay.io/kubevirt/tekton-task-modify-vm-template:" + operands.TektonTasksVersion
@@ -41,9 +42,15 @@ const (
 	DeafultCreateDatavolumeIMG  = "quay.io/openshift/origin-cli:4.8"
 	DeafultCopyTemplateIMG      = "quay.io/kubevirt/tekton-task-copy-template:" + operands.TektonTasksVersion
 	DeafultCleanupVMIMG         = "quay.io/kubevirt/tekton-task-execute-in-vm:" + operands.TektonTasksVersion
+	GenerateSSHKeysIMG          = "quay.io/kubevirt/tekton-task-generate-ssh-keys:" + operands.TektonTasksVersion
 
 	defaultOperatorVersion = "devel"
 )
+
+// GetSSHKeysStatusImage returns generate-ssh-keys task image url
+func GetSSHKeysStatusImage() string {
+	return EnvOrDefault(GenerateSSHKeysImageKey, GenerateSSHKeysIMG)
+}
 
 // GetWaitForVMIStatusImage returns wait-for-vmi-status task image url
 func GetWaitForVMIStatusImage() string {

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -118,6 +118,18 @@ var _ = Describe("environments", func() {
 		res := GetWaitForVMIStatusImage()
 		Expect(res).To(Equal(DefaultWaitForVMIStatusIMG), "WAIT_FOR_VMI_STATUS_IMG should equal")
 	})
+
+	It("should return correct value for GENERATE_SSH_KEYS_IMG when variable is set", func() {
+		os.Setenv(GenerateSSHKeysImageKey, testURL)
+		res := GetSSHKeysStatusImage()
+		Expect(res).To(Equal(testURL), "GENERATE_SSH_KEYS_IMG should equal")
+		os.Unsetenv(GenerateSSHKeysImageKey)
+	})
+
+	It("should return correct value for GENERATE_SSH_KEYS_IMG when variable is not set", func() {
+		res := GetSSHKeysStatusImage()
+		Expect(res).To(Equal(GenerateSSHKeysIMG), "GENERATE_SSH_KEYS_IMG should equal")
+	})
 })
 
 func TestTektonBundle(t *testing.T) {

--- a/pkg/tekton-tasks/tekton-tasks.go
+++ b/pkg/tekton-tasks/tekton-tasks.go
@@ -25,33 +25,40 @@ import (
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datavolumes,verbs=*
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines/finalizers,verbs=*
 // +kubebuilder:rbac:groups=*,resources=persistentvolumeclaims,verbs=*
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create
+// +kubebuilder:rbac:groups=*,resources=pods,verbs=create
+// +kubebuilder:rbac:groups=*,resources=secrets,verbs=*
 
 const (
 	operandName      = "tekton-tasks"
 	operandComponent = common.AppComponentTektonTasks
 
-	cleanVMTaskName           = "cleanup-vm"
-	copyTemplateTaskName      = "copy-template"
-	datavolumeTaskName        = "create-datavolume-from-manifest"
-	createVMTaskName          = "create-vm-from-template"
-	diskVirtCustomizeTaskName = "disk-virt-customize"
-	diskVirtSysprepTaskName   = "disk-virt-sysprep"
-	modifyTemplateTaskName    = "modify-vm-template"
-	waitForVMITaskName        = "wait-for-vmi-status"
+	cleanVMTaskName              = "cleanup-vm"
+	copyTemplateTaskName         = "copy-template"
+	datavolumeTaskName           = "create-datavolume-from-manifest"
+	createVMFromTemplateTaskName = "create-vm-from-template"
+	diskVirtCustomizeTaskName    = "disk-virt-customize"
+	diskVirtSysprepTaskName      = "disk-virt-sysprep"
+	modifyTemplateTaskName       = "modify-vm-template"
+	waitForVMITaskName           = "wait-for-vmi-status"
+	createVMFromManifestTaskName = "create-vm-from-manifest"
+	generateSSHKeysTaskName      = "generate-ssh-keys"
+	executeInVMTaskName          = "execute-in-vm"
 )
 
 var requiredCRDs = []string{"tasks.tekton.dev"}
 
 var AllowedTasks = map[string]func() string{
-	cleanVMTaskName:           environment.GetCleanupVMImage,
-	copyTemplateTaskName:      environment.GetCopyTemplateImage,
-	datavolumeTaskName:        environment.GetCreateDatavolumeImage,
-	createVMTaskName:          environment.GetCreateVMImage,
-	diskVirtCustomizeTaskName: environment.GetDiskVirtCustomizeImage,
-	diskVirtSysprepTaskName:   environment.GetDiskVirtSysprepImage,
-	modifyTemplateTaskName:    environment.GetModifyVMTemplateImage,
-	waitForVMITaskName:        environment.GetWaitForVMIStatusImage,
+	createVMFromManifestTaskName: environment.GetCreateVMImage,
+	cleanVMTaskName:              environment.GetCleanupVMImage,
+	copyTemplateTaskName:         environment.GetCopyTemplateImage,
+	datavolumeTaskName:           environment.GetCreateDatavolumeImage,
+	createVMFromTemplateTaskName: environment.GetCreateVMImage,
+	diskVirtCustomizeTaskName:    environment.GetDiskVirtCustomizeImage,
+	diskVirtSysprepTaskName:      environment.GetDiskVirtSysprepImage,
+	modifyTemplateTaskName:       environment.GetModifyVMTemplateImage,
+	waitForVMITaskName:           environment.GetWaitForVMIStatusImage,
+	generateSSHKeysTaskName:      environment.GetSSHKeysStatusImage,
+	executeInVMTaskName:          environment.GetCleanupVMImage,
 }
 
 func init() {

--- a/pkg/tekton-tasks/tekton-tasks_test.go
+++ b/pkg/tekton-tasks/tekton-tasks_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,10 +36,10 @@ var _ = Describe("environments", func() {
 
 	It("New function should return object with correct tasks", func() {
 		res := New(getMockedTestBundle())
-		Expect(len(res.clusterTasks)).To(Equal(8), "should return correct number of tasks")
-		Expect(len(res.serviceAccounts)).To(Equal(8), "should return correct number of service accounts")
-		Expect(len(res.roleBindings)).To(Equal(8), "should return correct number of role bindings")
-		Expect(len(res.clusterRoles)).To(Equal(8), "should return correct number of cluster roles")
+		Expect(len(res.clusterTasks)).To(Equal(11), "should return correct number of tasks")
+		Expect(len(res.serviceAccounts)).To(Equal(11), "should return correct number of service accounts")
+		Expect(len(res.roleBindings)).To(Equal(11), "should return correct number of role bindings")
+		Expect(len(res.clusterRoles)).To(Equal(11), "should return correct number of cluster roles")
 		for _, task := range res.clusterTasks {
 			if _, ok := AllowedTasks[task.Name]; !ok {
 				Expect(ok).To(BeTrue(), "only allowed task is deployed - "+task.Name)
@@ -136,7 +135,7 @@ func getMockedTektonTasksOperand() *tektonTasks {
 				Spec: pipeline.TaskSpec{
 					Steps: []pipeline.Step{
 						{
-							Container: corev1.Container{
+							Container: v1.Container{
 								Name: "test",
 							},
 						},
@@ -150,7 +149,7 @@ func getMockedTektonTasksOperand() *tektonTasks {
 				Spec: pipeline.TaskSpec{
 					Steps: []pipeline.Step{
 						{
-							Container: corev1.Container{
+							Container: v1.Container{
 								Name: "test",
 							},
 						},
@@ -204,7 +203,7 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 				Spec: pipeline.TaskSpec{
 					Steps: []pipeline.Step{
 						{
-							Container: corev1.Container{
+							Container: v1.Container{
 								Name: "test",
 							},
 						},
@@ -224,7 +223,7 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
-					Name: createVMTaskName,
+					Name: createVMFromManifestTaskName,
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
@@ -241,6 +240,18 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: modifyTemplateTaskName,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: generateSSHKeysTaskName,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: createVMFromManifestTaskName,
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: executeInVMTaskName,
 				},
 			},
 		},
@@ -263,7 +274,7 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
-					Name: createVMTaskName + "-task",
+					Name: createVMFromManifestTaskName + "-task",
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
@@ -280,6 +291,18 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: modifyTemplateTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: generateSSHKeysTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: createVMFromManifestTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: executeInVMTaskName + "-task",
 				},
 			},
 		},
@@ -302,7 +325,7 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
-					Name: createVMTaskName + "-task",
+					Name: createVMFromManifestTaskName + "-task",
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
@@ -319,6 +342,18 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: modifyTemplateTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: generateSSHKeysTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: createVMFromManifestTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: executeInVMTaskName + "-task",
 				},
 			},
 		},
@@ -341,7 +376,7 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
-					Name: createVMTaskName + "-task",
+					Name: createVMFromManifestTaskName + "-task",
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
@@ -358,6 +393,18 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: modifyTemplateTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: generateSSHKeysTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: createVMFromManifestTaskName + "-task",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: executeInVMTaskName + "-task",
 				},
 			},
 		},

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -26,46 +26,54 @@ var _ = Describe("Tekton-tasks", func() {
 
 		It("[test_id:TODO]operator should not create any cluster tasks", func() {
 			liveTasks := &pipeline.ClusterTaskList{}
-			err := apiClient.List(ctx, liveTasks,
-				client.MatchingLabels{
-					tektontasks.TektonTasksVersionLabel: operands.TektonTasksVersion,
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(liveTasks.Items) == 0).To(BeTrue(), "tasks should not exists")
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveTasks,
+					client.MatchingLabels{
+						tektontasks.TektonTasksVersionLabel: operands.TektonTasksVersion,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveTasks.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "tasks should not exists")
 		})
 
 		It("[test_id:TODO]operator should not create any service accounts", func() {
 			liveSA := &v1.ServiceAccountList{}
-			err := apiClient.List(ctx, liveSA,
-				client.MatchingLabels{
-					common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(liveSA.Items) == 0).To(BeTrue(), "service accounts should not exists")
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveSA,
+					client.MatchingLabels{
+						tektontasks.TektonTasksVersionLabel: operands.TektonTasksVersion,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveSA.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "service accounts should not exists")
 		})
 
 		It("[test_id:TODO]operator should not create any cluster role", func() {
 			liveCR := &rbac.ClusterRoleList{}
-			err := apiClient.List(ctx, liveCR,
-				client.MatchingLabels{
-					common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(liveCR.Items) == 0).To(BeTrue(), "cluster role should not exists")
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveCR,
+					client.MatchingLabels{
+						tektontasks.TektonTasksVersionLabel: operands.TektonTasksVersion,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveCR.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "cluster role should not exists")
 		})
 
 		It("[test_id:TODO]operator should not create role bindings", func() {
 			liveRB := &rbac.RoleBindingList{}
-			err := apiClient.List(ctx, liveRB,
-				client.MatchingLabels{
-					common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
-				},
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(liveRB.Items) == 0).To(BeTrue(), " role bindings should not exists")
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveRB,
+					client.MatchingLabels{
+						tektontasks.TektonTasksVersionLabel: operands.TektonTasksVersion,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveRB.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "role bindings should not exists")
 		})
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
add rest of the tasks to TTO
this PR add three extra tasks - create vm from manifest keys, generate ssh, execute in vm

Signed-off-by: Karel Šimon <ksimon@redhat.com>
Fixes: https://github.com/kubevirt/tekton-tasks-operator/issues/10
**Release note**:
```
Add create-vm-from-manifest and generate-ssh-keys tasks

```
