### PR TITLE
Add RoleBindings to tekton-pipelines bundle 

### DIFF
--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -15,14 +15,20 @@ import (
 )
 
 func CreateAndSetupReconciler(mgr controllerruntime.Manager) error {
-	ttBundle, err := tektonbundle.ReadBundle(mgr.GetAPIReader(), context.Background())
+	reader := mgr.GetAPIReader()
+	ctx := context.Background()
+	ttTasksBundle, err := tektonbundle.ReadTasksBundle(reader, ctx)
+	if err != nil {
+		return err
+	}
+	ttPipelinesBundle, err := tektonbundle.ReadPipelineBundle(reader, ctx)
 	if err != nil {
 		return err
 	}
 
 	tektonOperands := []operands.Operand{
-		tektontasks.New(ttBundle),
-		tektonpipelines.New(ttBundle),
+		tektontasks.New(ttTasksBundle),
+		tektonpipelines.New(ttPipelinesBundle),
 	}
 
 	var requiredCrds []string

--- a/data/tekton-pipelines/okd/windows-installer.yaml
+++ b/data/tekton-pipelines/okd/windows-installer.yaml
@@ -1,3 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: create-datavolume-from-manifest-task
+  namespace: kubevirt-os-images
+roleRef:
+  kind: ClusterRole
+  name: create-datavolume-from-manifest-task
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: create-datavolume-from-manifest-task
+  - kind: ServiceAccount
+    name: pipeline
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/tekton-bundle/tekton-bundle_test.go
+++ b/pkg/tekton-bundle/tekton-bundle_test.go
@@ -47,7 +47,15 @@ var _ = Describe("Tekton bundle", func() {
 		taskPath := filepath.Join(path, "test-bundle-files/test-tasks/test-tasks.yaml")
 		pipelinePath := filepath.Join(path, "test-bundle-files/test-pipelines/")
 
-		tektonObjs, err := decodeObjectsFromFiles(taskPath, pipelinePath)
+		taskFiles, err := readFile(taskPath)
+		Expect(err).ToNot(HaveOccurred())
+		pipelineFiles, err := readFolder(pipelinePath)
+		Expect(err).ToNot(HaveOccurred())
+		files := [][]byte{}
+		files = append(files, taskFiles...)
+		files = append(files, pipelineFiles...)
+
+		tektonObjs, err := decodeObjectsFromFiles(files)
 		Expect(err).ToNot(HaveOccurred(), "it should not throw error")
 		Expect(tektonObjs.ClusterTasks).To(HaveLen(numberOfClusterTasks), "number of tasks should equal")
 		Expect(tektonObjs.ServiceAccounts).To(HaveLen(numberOfServiceAccounts), "number of service accounts should equal")

--- a/pkg/tekton-pipelines/tekton-pipelines.go
+++ b/pkg/tekton-pipelines/tekton-pipelines.go
@@ -9,12 +9,14 @@ import (
 	tektonbundle "github.com/kubevirt/tekton-tasks-operator/pkg/tekton-bundle"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=*,resources=configmaps,verbs=list;watch;create;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 const (
 	operandName      = "tekton-pipelines"
@@ -28,16 +30,18 @@ func init() {
 }
 
 type tektonPipelines struct {
-	pipelines  []pipeline.Pipeline
-	configMaps []v1.ConfigMap
+	pipelines    []pipeline.Pipeline
+	configMaps   []v1.ConfigMap
+	roleBindings []rbac.RoleBinding
 }
 
 var _ operands.Operand = &tektonPipelines{}
 
 func New(bundle *tektonbundle.Bundle) *tektonPipelines {
 	tp := &tektonPipelines{
-		pipelines:  bundle.Pipelines,
-		configMaps: bundle.ConfigMaps,
+		pipelines:    bundle.Pipelines,
+		configMaps:   bundle.ConfigMaps,
+		roleBindings: bundle.RoleBindings,
 	}
 	return tp
 }
@@ -54,6 +58,7 @@ func (t *tektonPipelines) WatchTypes() []client.Object {
 	return []client.Object{
 		&pipeline.Pipeline{},
 		&v1.ConfigMap{},
+		&rbac.RoleBinding{},
 	}
 }
 
@@ -66,6 +71,7 @@ func (t *tektonPipelines) Reconcile(request *common.Request) ([]common.Reconcile
 	var reconcileFunc []common.ReconcileFunc
 	reconcileFunc = append(reconcileFunc, reconcileTektonPipelinesFuncs(t.pipelines)...)
 	reconcileFunc = append(reconcileFunc, reconcileConfigMapsFuncs(t.configMaps)...)
+	reconcileFunc = append(reconcileFunc, reconcileRoleBindingsFuncs(t.roleBindings)...)
 
 	reconcileTektonBundleResults, err := common.CollectResourceStatus(request, reconcileFunc...)
 	if err != nil {
@@ -89,6 +95,10 @@ func (t *tektonPipelines) Cleanup(request *common.Request) ([]common.CleanupResu
 	}
 	for _, cm := range t.configMaps {
 		o := cm.DeepCopy()
+		objects = append(objects, o)
+	}
+	for _, rb := range t.roleBindings {
+		o := rb.DeepCopy()
 		objects = append(objects, o)
 	}
 
@@ -134,6 +144,36 @@ func reconcileConfigMapsFuncs(configMaps []v1.ConfigMap) []common.ReconcileFunc 
 					newCM := newRes.(*v1.ConfigMap)
 					foundCM := foundRes.(*v1.ConfigMap)
 					foundCM.Data = newCM.Data
+				}).
+				Reconcile()
+		})
+	}
+	return funcs
+}
+
+func reconcileRoleBindingsFuncs(rbs []rbac.RoleBinding) []common.ReconcileFunc {
+	funcs := make([]common.ReconcileFunc, 0, len(rbs))
+	for i := range rbs {
+		rb := &rbs[i]
+		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
+			namespace := request.Instance.Namespace
+			if rb.Namespace == "" {
+				rb.Namespace = namespace
+			}
+			for j := range rb.Subjects {
+				subject := &rb.Subjects[j]
+				if subject.Namespace == "" {
+					subject.Namespace = namespace
+				}
+			}
+			return common.CreateOrUpdate(request).
+				ClusterResource(rb).
+				WithAppLabels(operandName, operandComponent).
+				UpdateFunc(func(newRes, foundRes client.Object) {
+					newTask := newRes.(*rbac.RoleBinding)
+					foundTask := foundRes.(*rbac.RoleBinding)
+					foundTask.RoleRef = newTask.RoleRef
+					foundTask.Subjects = newTask.Subjects
 				}).
 				Reconcile()
 		})

--- a/pkg/tekton-pipelines/tekton-pipelines_test.go
+++ b/pkg/tekton-pipelines/tekton-pipelines_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -36,6 +37,7 @@ var _ = Describe("environments", func() {
 		res := New(getMockedTestBundle())
 		Expect(len(res.pipelines)).To(Equal(2), "should return correct number of pipelines")
 		Expect(len(res.configMaps)).To(Equal(2), "should return correct number of config maps")
+		Expect(len(res.roleBindings)).To(Equal(2), "should return correct number of rolebindings")
 	})
 
 	It("Name function should return correct name", func() {
@@ -46,7 +48,7 @@ var _ = Describe("environments", func() {
 	It("Reconcile function should return correct functions", func() {
 		functions, err := tp.Reconcile(mockedRequest)
 		Expect(err).ToNot(HaveOccurred(), "should not throw err")
-		Expect(len(functions)).To(Equal(4), "should return correct number of reconcile functions")
+		Expect(len(functions)).To(Equal(6), "should return correct number of reconcile functions")
 	})
 
 	It("RequiredCrds function should return required crds", func() {
@@ -87,7 +89,7 @@ func getMockedRequest() *common.Request {
 		Context: context.Background(),
 		Instance: &tekton.TektonTasks{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "TetktonTasks",
+				Kind:       "TektonTasks",
 				APIVersion: tekton.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -123,6 +125,17 @@ func getMockedTektonPipelinesOperand() *tektonPipelines {
 					Name: "test-cm2",
 				},
 			},
+		},
+		roleBindings: []rbac.RoleBinding{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rb",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rb2",
+				},
+			},
 		}}
 }
 
@@ -147,6 +160,17 @@ func getMockedTestBundle() *tektonbundle.Bundle {
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cm2",
+				},
+			},
+		},
+		RoleBindings: []rbac.RoleBinding{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rb",
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rb2",
 				},
 			},
 		},

--- a/pkg/tekton-tasks/tekton-tasks.go
+++ b/pkg/tekton-tasks/tekton-tasks.go
@@ -25,6 +25,7 @@ import (
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datavolumes,verbs=*
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines/finalizers,verbs=*
 // +kubebuilder:rbac:groups=*,resources=persistentvolumeclaims,verbs=*
+// +kubebuilder:rbac:groups="",resources=pods,verbs=create
 
 const (
 	operandName      = "tekton-tasks"

--- a/tests/tekton-pipelines_test.go
+++ b/tests/tekton-pipelines_test.go
@@ -1,14 +1,17 @@
 package tests
 
 import (
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubevirt/tekton-tasks-operator/pkg/common"
+	tektontasks "github.com/kubevirt/tekton-tasks-operator/pkg/tekton-tasks"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	rbac "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Tekton-pipelines", func() {
@@ -37,6 +40,27 @@ var _ = Describe("Tekton-pipelines", func() {
 				Expect(pipeline.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
 			}
 		})
+
+		It("[test_id:TODO]operator should create role bindings", func() {
+			liveRB := &rbac.RoleBindingList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveRB,
+					client.MatchingLabels{
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveRB.Items) > 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue())
+
+			for _, rb := range liveRB.Items {
+				if _, ok := tektontasks.AllowedTasks[strings.TrimSuffix(rb.Name, "-task")]; !ok {
+					Expect(ok).To(BeTrue(), "only allowed role binding is deployed - "+rb.Name)
+				}
+				Expect(rb.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
+			}
+		})
 	})
 
 	Context("resource deletion when CR is deleted", func() {
@@ -60,6 +84,20 @@ var _ = Describe("Tekton-pipelines", func() {
 				Expect(err).ToNot(HaveOccurred())
 				return len(livePipelines.Items) == 0
 			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no pipelines left")
+		})
+
+		It("[test_id:TODO]operator should delete role bindings", func() {
+			liveRB := &rbac.RoleBindingList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveRB,
+					client.MatchingLabels{
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveRB.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no role bindings left")
 		})
 	})
 })

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -144,6 +144,7 @@ var _ = Describe("Tekton-tasks", func() {
 			Eventually(func() bool {
 				err := apiClient.List(ctx, liveRB,
 					client.MatchingLabels{
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonTasks),
 						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
 					},
 				)
@@ -155,7 +156,6 @@ var _ = Describe("Tekton-tasks", func() {
 				if _, ok := tektontasks.AllowedTasks[strings.TrimSuffix(rb.Name, "-task")]; !ok {
 					Expect(ok).To(BeTrue(), "only allowed role binding is deployed - "+rb.Name)
 				}
-				Expect(rb.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonTasks)), "component label should equal")
 				Expect(rb.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
 			}
 		})
@@ -216,6 +216,7 @@ var _ = Describe("Tekton-tasks", func() {
 			Eventually(func() bool {
 				err := apiClient.List(ctx, liveRB,
 					client.MatchingLabels{
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonTasks),
 						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
 					},
 				)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With this change RoleBindings specified in the tekton-pipelines bundle
will be applied to the cluster. It is allowed to specify a different
Namespace than the one the managing TTO is running in. The Namespace
of every subject in the RoleBinding is set to the Namespace of the
managing TTO.

The reading in of Tasks and Pipelines bundles is separated so tekton-tasks
and tekton-pipeline RoleBindings can be handled separately.

**Special notes for your reviewer**:

Merge after #31 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add RoleBindings to tekton-pipelines bundle
```
