### PR TITLE
handle object modified error in initialize steps

### DIFF
--- a/controllers/tektontasks_controller.go
+++ b/controllers/tektontasks_controller.go
@@ -112,9 +112,7 @@ func (r *tektonTasksReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if !isInitialized(tektonRequest.Instance) {
 		err := initialize(tektonRequest)
-		// No need to requeue here, because
-		// the update will trigger reconciliation again
-		return ctrl.Result{}, err
+		return handleError(tektonRequest, err)
 	}
 
 	if updated, err := updateTektonTasks(tektonRequest); updated || (err != nil) {


### PR DESCRIPTION
**What this PR does / why we need it**:
handle object modified error in initialize steps

not handling object modified error in initialize step caused tests to
be flaky.


**Release note**:
```
NONE

```
