### PR TITLE
tto watches all objects it deploys

### DIFF
--- a/pkg/tekton-pipelines/tekton-pipelines.go
+++ b/pkg/tekton-pipelines/tekton-pipelines.go
@@ -51,15 +51,15 @@ func (t *tektonPipelines) Name() string {
 }
 
 func (t *tektonPipelines) WatchClusterTypes() []client.Object {
-	return nil
-}
-
-func (t *tektonPipelines) WatchTypes() []client.Object {
 	return []client.Object{
 		&pipeline.Pipeline{},
 		&v1.ConfigMap{},
 		&rbac.RoleBinding{},
 	}
+}
+
+func (t *tektonPipelines) WatchTypes() []client.Object {
+	return nil
 }
 
 func (t *tektonPipelines) RequiredCrds() []string {

--- a/pkg/tekton-tasks/tekton-tasks.go
+++ b/pkg/tekton-tasks/tekton-tasks.go
@@ -95,14 +95,13 @@ func (t *tektonTasks) WatchClusterTypes() []client.Object {
 	return []client.Object{
 		&rbac.ClusterRole{},
 		&pipeline.ClusterTask{},
+		&rbac.RoleBinding{},
+		&v1.ServiceAccount{},
 	}
 }
 
 func (t *tektonTasks) WatchTypes() []client.Object {
-	return []client.Object{
-		&rbac.RoleBinding{},
-		&v1.ServiceAccount{},
-	}
+	return nil
 }
 
 func (t *tektonTasks) RequiredCrds() []string {


### PR DESCRIPTION
**What this PR does / why we need it**:
tto watches all objects it deploys

Previously tto watched only cluster objects, now it should watch
all objects and revert all user changes
**Which issue(s) this PR fixes**:
Fixes [29](https://github.com/kubevirt/tekton-tasks-operator/issues/29)

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
