### PR TITLE
Fix windows10-customize pipeline on kubernetes

### DIFF
--- a/data/tekton-pipelines/kubernetes/windows10-customize.yaml
+++ b/data/tekton-pipelines/kubernetes/windows10-customize.yaml
@@ -246,6 +246,8 @@ spec:
         - name: dataVolumes
           value:
             - "rootdisk: $(tasks.create-base-dv.results.name)"
+        - name: runStrategy
+          value: RerunOnFailure
         - name: startVM
           value: "true"
       runAfter:
@@ -263,7 +265,7 @@ spec:
         - name: failureCondition
           value: status.phase in (Failed, Unknown)
       runAfter:
-        - create-vm-from-template
+        - create-vm-from-manifest
       timeout: 2h
       taskRef:
         kind: ClusterTask


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There was a reference to a task in runAfter with the wrong task name and
the runStrategy parameter was missing when starting the customize VM.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
