### PR TITLE
Fix usage of baseDvName and baseDvNamespace parameters

### DIFF
--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -305,8 +305,8 @@ spec:
             apiVersion: cdi.kubevirt.io/v1beta1
             kind: DataVolume
             metadata:
-              name: win10
-              namespace: openshift-virtualization-os-images
+              name: $(params.baseDvName)
+              namespace: $(params.baseDvNamespace)
               annotations:
                 cdi.kubevirt.io/storage.bind.immediate.requested: \"true\"
             spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Hardcoded values instead of the parameters were used by mistake.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
