### PR TITLE
remove prometheus label and port from deploy manifest

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         control-plane: tekton-tasks-operator
         name: tekton-tasks-operator
-        prometheus.kubevirt.io: "true"
     spec:
       serviceAccountName: tekton-tasks-operator
       priorityClassName: system-cluster-critical
@@ -61,10 +60,6 @@ spec:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        ports:
-          - name: metrics
-            protocol: TCP
-            containerPort: 8443
         readinessProbe:
           httpGet:
             path: /readyz

--- a/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
@@ -238,7 +238,6 @@ spec:
               labels:
                 control-plane: tekton-tasks-operator
                 name: tekton-tasks-operator
-                prometheus.kubevirt.io: "true"
               namespace: kubevirt
             spec:
               containers:
@@ -270,10 +269,6 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
-                ports:
-                - containerPort: 8443
-                  name: metrics
-                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz


### PR DESCRIPTION
**What this PR does / why we need it**:
remove prometheus label and port from deploy manifest

currently there is no support planned for prometheus, so to prevent
issues, I am removing prometheus data from deploy manifests

Signed-off-by: Karel Šimon <ksimon@redhat.com>
Fixes: https://github.com/kubevirt/tekton-tasks-operator/issues/50, https://github.com/kubevirt/tekton-tasks-operator/issues/49
**Release note**:
```
remove prometheus label and port from deploy manifests

```
