### PR TITLE
add pipeline service account into installer pipeline

### DIFF
--- a/data/tekton-pipelines/kubernetes/windows10-installer.yaml
+++ b/data/tekton-pipelines/kubernetes/windows10-installer.yaml
@@ -119,6 +119,11 @@ data:
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:

--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -14,6 +14,11 @@ subjects:
     name: pipeline
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: windows10-autounattend

--- a/pkg/tekton-pipelines/tekton-pipelines.go
+++ b/pkg/tekton-pipelines/tekton-pipelines.go
@@ -2,6 +2,7 @@ package tekton_pipelines
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/kubevirt/tekton-tasks-operator/pkg/common"
 	"github.com/kubevirt/tekton-tasks-operator/pkg/environment"
@@ -19,9 +20,12 @@ import (
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 const (
+	namespacePattern = "^(openshift|kube)-"
 	operandName      = "tekton-pipelines"
 	operandComponent = common.AppComponentTektonPipelines
 )
+
+var namespaceRegex = regexp.MustCompile(namespacePattern)
 
 var requiredCRDs = []string{"tasks.tekton.dev"}
 
@@ -30,18 +34,20 @@ func init() {
 }
 
 type tektonPipelines struct {
-	pipelines    []pipeline.Pipeline
-	configMaps   []v1.ConfigMap
-	roleBindings []rbac.RoleBinding
+	pipelines       []pipeline.Pipeline
+	configMaps      []v1.ConfigMap
+	roleBindings    []rbac.RoleBinding
+	serviceAccounts []v1.ServiceAccount
 }
 
 var _ operands.Operand = &tektonPipelines{}
 
 func New(bundle *tektonbundle.Bundle) *tektonPipelines {
 	tp := &tektonPipelines{
-		pipelines:    bundle.Pipelines,
-		configMaps:   bundle.ConfigMaps,
-		roleBindings: bundle.RoleBindings,
+		pipelines:       bundle.Pipelines,
+		configMaps:      bundle.ConfigMaps,
+		roleBindings:    bundle.RoleBindings,
+		serviceAccounts: bundle.ServiceAccounts,
 	}
 	return tp
 }
@@ -55,6 +61,7 @@ func (t *tektonPipelines) WatchClusterTypes() []client.Object {
 		&pipeline.Pipeline{},
 		&v1.ConfigMap{},
 		&rbac.RoleBinding{},
+		&v1.ServiceAccount{},
 	}
 }
 
@@ -72,6 +79,7 @@ func (t *tektonPipelines) Reconcile(request *common.Request) ([]common.Reconcile
 	reconcileFunc = append(reconcileFunc, reconcileTektonPipelinesFuncs(t.pipelines)...)
 	reconcileFunc = append(reconcileFunc, reconcileConfigMapsFuncs(t.configMaps)...)
 	reconcileFunc = append(reconcileFunc, reconcileRoleBindingsFuncs(t.roleBindings)...)
+	reconcileFunc = append(reconcileFunc, reconcileServiceAccountsFuncs(request, t.serviceAccounts)...)
 
 	reconcileTektonBundleResults, err := common.CollectResourceStatus(request, reconcileFunc...)
 	if err != nil {
@@ -99,6 +107,10 @@ func (t *tektonPipelines) Cleanup(request *common.Request) ([]common.CleanupResu
 	}
 	for _, rb := range t.roleBindings {
 		o := rb.DeepCopy()
+		objects = append(objects, o)
+	}
+	for _, sa := range t.serviceAccounts {
+		o := sa.DeepCopy()
 		objects = append(objects, o)
 	}
 
@@ -144,6 +156,36 @@ func reconcileConfigMapsFuncs(configMaps []v1.ConfigMap) []common.ReconcileFunc 
 					newCM := newRes.(*v1.ConfigMap)
 					foundCM := foundRes.(*v1.ConfigMap)
 					foundCM.Data = newCM.Data
+				}).
+				Reconcile()
+		})
+	}
+	return funcs
+}
+
+func reconcileServiceAccountsFuncs(r *common.Request, sas []v1.ServiceAccount) []common.ReconcileFunc {
+	funcs := make([]common.ReconcileFunc, 0, len(sas))
+	for i := range sas {
+		sa := &sas[i]
+		// deploy pipeline SA only in `^(openshift|kube)-` namespaces
+		if !namespaceRegex.MatchString(r.Instance.Spec.Pipelines.Namespace) && sa.Name == "pipeline" {
+			continue
+		}
+
+		funcs = append(funcs, func(request *common.Request) (common.ReconcileResult, error) {
+			namespace := request.Instance.Namespace
+			if sa.Namespace == "" {
+				sa.Namespace = namespace
+			}
+			return common.CreateOrUpdate(request).
+				ClusterResource(sa).
+				WithAppLabels(operandName, operandComponent).
+				UpdateFunc(func(newRes, foundRes client.Object) {
+					newSA := newRes.(*v1.ServiceAccount)
+					foundSA := foundRes.(*v1.ServiceAccount)
+					foundSA.Secrets = newSA.Secrets
+					foundSA.ImagePullSecrets = newSA.ImagePullSecrets
+					foundSA.AutomountServiceAccountToken = newSA.AutomountServiceAccountToken
 				}).
 				Reconcile()
 		})

--- a/tests/tekton-pipelines_test.go
+++ b/tests/tekton-pipelines_test.go
@@ -42,6 +42,20 @@ var _ = Describe("Tekton-pipelines", func() {
 			}
 		})
 
+		It("[test_id:TODO]operator should not create service accounts with pipelines in non ^openshift|kube namespace", func() {
+			liveSA := &v1.ServiceAccountList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveSA,
+					client.MatchingLabels{
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveSA.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no service accounts deployed with pipelines")
+		})
+
 		It("[test_id:TODO]operator should create role bindings", func() {
 			liveRB := &rbac.RoleBindingList{}
 			Eventually(func() bool {

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -113,6 +113,7 @@ var _ = Describe("Tekton-tasks", func() {
 				err := apiClient.List(ctx, liveSA,
 					client.MatchingLabels{
 						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonTasks),
 					},
 				)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
add pipeline service account into installer pipeline
Tekton operator does not deploy pipeline SA in ^openshift|kube
namespaces. This PR deploys it if tekton operator is deployed in namespace which passes regex

**Release note**:
```
Deploy pipeline serviceAccount in the same namespace as tekton-tasks operator

```
