### PR TITLE
add pipeline service account into installer pipeline

### DIFF
--- a/data/tekton-pipelines/kubernetes/windows10-installer.yaml
+++ b/data/tekton-pipelines/kubernetes/windows10-installer.yaml
@@ -119,6 +119,11 @@ data:
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:

--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -14,6 +14,11 @@ subjects:
     name: pipeline
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: windows10-autounattend

--- a/tests/tekton-pipelines_test.go
+++ b/tests/tekton-pipelines_test.go
@@ -42,6 +42,20 @@ var _ = Describe("Tekton-pipelines", func() {
 			}
 		})
 
+		It("[test_id:TODO]operator should not create service accounts with pipelines in non ^openshift|kube namespace", func() {
+			liveSA := &v1.ServiceAccountList{}
+			Eventually(func() bool {
+				err := apiClient.List(ctx, liveSA,
+					client.MatchingLabels{
+						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				return len(liveSA.Items) == 0
+			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no service accounts deployed with pipelines")
+		})
+
 		It("[test_id:TODO]operator should create role bindings", func() {
 			liveRB := &rbac.RoleBindingList{}
 			Eventually(func() bool {

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -113,6 +113,7 @@ var _ = Describe("Tekton-tasks", func() {
 				err := apiClient.List(ctx, liveSA,
 					client.MatchingLabels{
 						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
+						common.AppKubernetesComponentLabel: string(common.AppComponentTektonTasks),
 					},
 				)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Tekton operator does not deploy pipeline SA in ^openshift|kube
namespaces. This PR deploys it

Signed-off-by: Karel Šimon <ksimon@redhat.com>

```release-note
Deploy pipeline serviceAccount in the same namespace as tekton-tasks operator
```