### PR TITLE
add cluster role in pipelines when deployed in ^openshift|kube namespace

### DIFF
--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -1,6 +1,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: windows10-pipelines
+roleRef:
+  kind: ClusterRole
+  name: windows10-pipelines
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: create-datavolume-from-manifest-task
   namespace: kubevirt-os-images
 roleRef:
@@ -17,6 +29,89 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pipeline
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: windows10-pipelines
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+    apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - pods
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    apiGroups:
+      - template.openshift.io
+    resources:
+      - templates
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+    apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+  - verbs:
+      - '*'
+    apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines/finalizers
+  - verbs:
+      - create
+    apiGroups:
+      - template.openshift.io
+    resources:
+      - processedtemplates
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+  - verbs:
+      - '*'
+    apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
+  - verbs:
+      - update
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**What this PR does / why we need it**:
add cluster role in pipelines
when pipeline is deployed in ^openshift|kube namespace
it requires more permissions to run

**Release note**:
```
Deploy extra cluster role, when deployed in ^openshift|kube namespace

```
