### PR TITLE
fix deploying of windows10-pipelines clusterrole

### DIFF
--- a/pkg/tekton-pipelines/tekton-pipelines.go
+++ b/pkg/tekton-pipelines/tekton-pipelines.go
@@ -217,6 +217,7 @@ func reconcileClusterRolesFuncs(r *common.Request, crs []rbac.ClusterRole) []com
 					foundCR := foundRes.(*rbac.ClusterRole)
 					foundCR.Labels = newCR.Labels
 					foundCR.Annotations = newCR.Annotations
+					foundCR.Rules = newCR.Rules
 				}).
 				Reconcile()
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
fix deploying of windows10-pipelines clusterrole

**Release note**:
```
NONE
```
