### PR TITLE
Update examples pipelines to use create-data-object task

### DIFF
--- a/data/tekton-pipelines/kubernetes/windows10-customize.yaml
+++ b/data/tekton-pipelines/kubernetes/windows10-customize.yaml
@@ -160,7 +160,7 @@ spec:
       timeout: 10m
       taskRef:
         kind: ClusterTask
-        name: create-datavolume-from-manifest
+        name: create-data-object
     - name: create-vm-from-manifest
       params:
         - name: manifest

--- a/data/tekton-pipelines/kubernetes/windows10-installer.yaml
+++ b/data/tekton-pipelines/kubernetes/windows10-installer.yaml
@@ -161,7 +161,7 @@ spec:
       timeout: 10m
       taskRef:
         kind: ClusterTask
-        name: create-datavolume-from-manifest
+        name: create-data-object
     - name: create-base-dv
       params:
         - name: manifest
@@ -180,7 +180,7 @@ spec:
       timeout: 10m
       taskRef:
         kind: ClusterTask
-        name: create-datavolume-from-manifest
+        name: create-data-object
     - name: create-vm-from-manifest
       params:
         - name: manifest

--- a/data/tekton-pipelines/okd/windows10-customize.yaml
+++ b/data/tekton-pipelines/okd/windows10-customize.yaml
@@ -274,7 +274,7 @@ spec:
       timeout: 1h
       taskRef:
         kind: ClusterTask
-        name: create-datavolume-from-manifest
+        name: create-data-object
     - name: cleanup-vm
       params:
         - name: vmName

--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -13,15 +13,15 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: create-datavolume-from-manifest-task
+  name: create-data-object-task
   namespace: kubevirt-os-images
 roleRef:
   kind: ClusterRole
-  name: create-datavolume-from-manifest-task
+  name: create-data-object-task
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: create-datavolume-from-manifest-task
+    name: create-data-object-task
   - kind: ServiceAccount
     name: pipeline
 ---
@@ -425,7 +425,7 @@ spec:
       timeout: 1h
       taskRef:
         kind: ClusterTask
-        name: create-datavolume-from-manifest
+        name: create-data-object
     - name: cleanup-vm
       params:
         - name: vmName


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Update the example pipelines to replace create-datavolume-from-manifest
with create-data-object task introduced in the kubevirt-tekton-tasks
v0.10.0.

Example windows10-installer PipelineRun for kubernetes:
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: windows10-installer-run-
spec:
  params:
  - name: winImageDownloadURL
    value: INSERT_WINDOWS_ISO_URL
  pipelineRef:
    name: windows10-installer
  serviceAccountNames:
    - taskName: create-source-dv
      serviceAccountName: create-data-object-task
    - taskName: create-base-dv
      serviceAccountName: create-data-object-task
    - taskName: create-vm-from-manifest
      serviceAccountName: create-vm-from-manifest-task
    - taskName: wait-for-vmi-status
      serviceAccountName: wait-for-vmi-status-task
    - taskName: cleanup-vm
      serviceAccountName: cleanup-vm-task
status: {}
```

Example windows10-installer PipelineRun for okd:
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: windows10-installer-run-
spec:
  params:
  - name: winImageDownloadURL
    value: INSERT_WINDOWS_ISO_URL
  pipelineRef:
    name: windows10-installer
  serviceAccountNames:
    - taskName: copy-template
      serviceAccountName: copy-template-task
    - taskName: modify-vm-template
      serviceAccountName: modify-vm-template-task
    - taskName: create-vm-from-template
      serviceAccountName: create-vm-from-template-task
    - taskName: wait-for-vmi-status
      serviceAccountName: wait-for-vmi-status-task
    - taskName: create-base-dv
      serviceAccountName: create-data-object-task
    - taskName: cleanup-vm
      serviceAccountName: cleanup-vm-task
status: {}
```

Example windows10-customize PipelineRun for kubernetes:
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: windows10-customize-run-
spec:
  params:
  - name: sourceDataVolumeName
    value: INSERT_NAME_OF_SOURCE_DATAVOLUME
  - name: sourceDataVolumeNamespace
    value: INSERT_NAMESPACE_OF_SOURCE_DATAVOLUME
  pipelineRef:
    name: windows10-customize
  serviceAccountNames:
    - taskName: create-base-dv
      serviceAccountName: create-data-object-task
    - taskName: create-vm-from-manifest
      serviceAccountName: create-vm-from-manifest-task
    - taskName: wait-for-vmi-status
      serviceAccountName: wait-for-vmi-status-task
    - taskName: cleanup-vm
      serviceAccountName: cleanup-vm-task
status: {}
```

Example windows10-customize PipelineRun for okd:
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: windows10-customize-run-
spec:
  pipelineRef:
    name: windows10-customize
  serviceAccountNames:
    - taskName: copy-template-customize
      serviceAccountName: copy-template-task
    - taskName: modify-vm-template-customize
      serviceAccountName: modify-vm-template-task
    - taskName: create-vm-from-template
      serviceAccountName: create-vm-from-template-task
    - taskName: wait-for-vmi-status
      serviceAccountName: wait-for-vmi-status-task
    - taskName: create-base-dv
      serviceAccountName: create-data-object-task
    - taskName: cleanup-vm
      serviceAccountName: cleanup-vm-task
    - taskName: copy-template-golden
      serviceAccountName: copy-template-task
    - taskName: modify-vm-template-golden
      serviceAccountName: modify-vm-template-task
status: {}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
