### PR TITLE
Add deployment of SSP to deployment script, that is needed for run of example pipelines

### DIFF
--- a/scripts/ssp-sample.yaml
+++ b/scripts/ssp-sample.yaml
@@ -1,0 +1,10 @@
+apiVersion: ssp.kubevirt.io/v1beta1
+kind: SSP
+metadata:
+  name: ssp-sample
+  namespace: kubevirt
+spec:
+  commonTemplates:
+    namespace: openshift
+  templateValidator:
+    replicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Add deployment of SSP operator that is needed to run example pipelines to deployment script. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```None

```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>