### PR TITLE
Add permissions to SA used by windows10-installer pipeline

### DIFF
--- a/data/tekton-pipelines/kubernetes/windows10-installer.yaml
+++ b/data/tekton-pipelines/kubernetes/windows10-installer.yaml
@@ -1,3 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: windows10-pipelines
+roleRef:
+  kind: ClusterRole
+  name: windows10-pipelines
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: windows10-pipelines
+rules:
+- apiGroups: ["kubevirt.io"]
+  resources: ["virtualmachines/finalizers"]
+  verbs: ["*"]
+  
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -118,11 +145,6 @@ data:
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: pipeline
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds permissions to SA that is used by windows10-installer pipeline that were needed to run pipeline without error.

**Which issue(s) this PR fixes** :

Fixes https://github.com/kubevirt/kubevirt-tekton-tasks/issues/163

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```None

```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>