### PR TITLE
Edit tests for clusterRole and roleBinding creation

### DIFF
--- a/tests/tekton-pipelines_test.go
+++ b/tests/tekton-pipelines_test.go
@@ -42,22 +42,9 @@ var _ = Describe("Tekton-pipelines", func() {
 			}
 		})
 
-		It("[test_id:TODO]operator should not create service accounts with pipelines in non ^openshift|kube namespace", func() {
-			liveSA := &v1.ServiceAccountList{}
-			Eventually(func() bool {
-				err := apiClient.List(ctx, liveSA,
-					client.MatchingLabels{
-						common.AppKubernetesManagedByLabel: common.AppKubernetesManagedByValue,
-						common.AppKubernetesComponentLabel: string(common.AppComponentTektonPipelines),
-					},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				return len(liveSA.Items) == 0
-			}, tenSecondTimeout, time.Second).Should(BeTrue(), "there should be no service accounts deployed with pipelines")
-		})
-
 		It("[test_id:TODO]operator should create role bindings", func() {
 			liveRB := &rbac.RoleBindingList{}
+			roleBindingName := "windows10-pipelines"
 			Eventually(func() bool {
 				err := apiClient.List(ctx, liveRB,
 					client.MatchingLabels{
@@ -71,7 +58,9 @@ var _ = Describe("Tekton-pipelines", func() {
 
 			for _, rb := range liveRB.Items {
 				if _, ok := tektontasks.AllowedTasks[strings.TrimSuffix(rb.Name, "-task")]; !ok {
-					Expect(ok).To(BeTrue(), "only allowed role binding is deployed - "+rb.Name)
+					if ok = rb.Name != roleBindingName; ok {
+						Expect(ok).To(BeTrue(), "only allowed role binding is deployed - "+rb.Name)
+					}
 				}
 				Expect(rb.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
 			}

--- a/tests/tekton-tasks_test.go
+++ b/tests/tekton-tasks_test.go
@@ -130,6 +130,7 @@ var _ = Describe("Tekton-tasks", func() {
 
 		It("[test_id:TODO]operator should create cluster role", func() {
 			liveCR := &rbac.ClusterRoleList{}
+			clusterRoleName := "windows10-pipelines"
 			Eventually(func() bool {
 				err := apiClient.List(ctx, liveCR,
 					client.MatchingLabels{
@@ -141,9 +142,16 @@ var _ = Describe("Tekton-tasks", func() {
 			}, tenSecondTimeout, time.Second).Should(BeTrue())
 			for _, cr := range liveCR.Items {
 				if _, ok := tektontasks.AllowedTasks[strings.TrimSuffix(cr.Name, "-task")]; !ok {
-					Expect(ok).To(BeTrue(), "only allowed cluster role is deployed - "+cr.Name)
+					if ok = cr.Name != clusterRoleName; ok {
+						Expect(ok).To(BeTrue(), "only allowed cluster role is deployed - "+cr.Name)
+					}
 				}
-				Expect(cr.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonTasks)), "component label should equal")
+
+				if cr.Name == clusterRoleName {
+					Expect(cr.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonPipelines)), "component label should equal")
+				} else {
+					Expect(cr.Labels[common.AppKubernetesComponentLabel]).To(Equal(string(common.AppComponentTektonTasks)), "component label should equal")
+				}
 				Expect(cr.Labels[common.AppKubernetesManagedByLabel]).To(Equal(common.AppKubernetesManagedByValue), "managed by label should equal")
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR edits tests, so they will pass when `windows10-pipelines` clusterRole and roleBinding is created.

**Release note**:
```None

```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>