### PR TITLE
Add permissions to pipeline SA in kubevirt-os-images namespace

### DIFF
--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -13,15 +13,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: modify-data-object-task
+  name: windows10-pipelines
   namespace: kubevirt-os-images
 roleRef:
   kind: ClusterRole
-  name: modify-data-object-task
+  name: windows10-pipelines
   apiGroup: rbac.authorization.k8s.io
 subjects:
-  - kind: ServiceAccount
-    name: modify-data-object-task
   - kind: ServiceAccount
     name: pipeline
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds permissions to SA in kubevirt-os-images namespace and removes dependency on `modify-data-object-task`, so pipeline and clusterTasks can be created in parallel.

**Release note**:
```None

```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>