### PR TITLE
Delete resources that are created during the run of example pipelines and set allowReplace of base datavolume.

### DIFF
--- a/data/tekton-pipelines/okd/windows10-customize.yaml
+++ b/data/tekton-pipelines/okd/windows10-customize.yaml
@@ -352,13 +352,18 @@ spec:
       taskRef:
         kind: ClusterTask
         name: cleanup-vm
+    - name: delete-template-customize
+      params:
+        - name: templateName
+          value: $(params.customizeTemplateName)
+        - name: templateNamespace
+          value: $(tasks.copy-template-customize.results.namespace)
+        - name: deleteTemplate
+          value: "true"
+      taskRef:
+        kind: ClusterTask
+        name: modify-vm-template
   results:
-    - name: customizeTemplateName
-      description: Name of the created customize Template
-      value: $(tasks.copy-template-customize.results.name)
-    - name: customizeTemplateNamespace
-      description: Namespace of the created customize Template
-      value: $(tasks.copy-template-customize.results.namespace)
     - name: baseDvName
       description: Name of the created base DataVolume
       value: $(tasks.create-base-dv.results.name)

--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -34,15 +34,6 @@ metadata:
   name: windows10-pipelines
 rules:
   - verbs:
-      - get
-      - list
-      - watch
-      - create
-    apiGroups:
-      - cdi.kubevirt.io
-    resources:
-      - datavolumes
-  - verbs:
       - create
     apiGroups:
       - ""
@@ -95,12 +86,6 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
-  - verbs:
-      - 'update'
-    apiGroups:
-      - subresources.kubevirt.io
-    resources:
-      - virtualmachines/start
   - verbs:
       - update
     apiGroups:
@@ -415,6 +400,8 @@ spec:
                   namespace: $(tasks.create-vm-from-template.results.namespace)
         - name: waitForSuccess
           value: "true"
+        - name: allowReplace
+          value: "true"
       runAfter:
         - wait-for-vmi-status
       timeout: 1h
@@ -432,6 +419,17 @@ spec:
       taskRef:
         kind: ClusterTask
         name: cleanup-vm
+    - name: delete-template
+      params:
+        - name: templateName
+          value: $(params.installerTemplateName)
+        - name: templateNamespace
+          value: $(tasks.modify-vm-template.results.namespace)
+        - name: deleteTemplate
+          value: "true"
+      taskRef:
+        kind: ClusterTask
+        name: modify-vm-template
   results:
     - name: installerTemplateName
       description: Name of the created installer Template


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds new functionality of tekton tasks that allows us to delete resources like data volumes and templates to the example pipelines. Example pipelines will now delete resources that are created during the run of pipelines, but they are not part of pipelines results. 

This PR also sets allowReplace to the windows-installer pipeline base datavolume so it can be run repeatedly.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
```None

```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>