### PR TITLE
Add annotations to example pipelines datavolumes.

### DIFF
--- a/data/tekton-pipelines/okd/windows10-customize.yaml
+++ b/data/tekton-pipelines/okd/windows10-customize.yaml
@@ -252,6 +252,7 @@ spec:
               generateName: windows10-base-
               annotations:
                 cdi.kubevirt.io/storage.bind.immediate.requested: \"true\"
+                cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
             spec:
               storage:
                 resources:

--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -392,6 +392,7 @@ spec:
               namespace: $(params.baseDvNamespace)
               annotations:
                 cdi.kubevirt.io/storage.bind.immediate.requested: \"true\"
+                cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
             spec:
               storage: {}
               source:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds annotations to example pipelines datavolumes that will not allow CDI gabage collector delete these datavolumes.

**Release note**:
```None

```
Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>