### PR TITLE
update golang version to 1.18 in github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Get release
         id: get_release


### PR DESCRIPTION
**What this PR does / why we need it**:
update golang version to 1.18 in github actions

**Release note**:
```
NONE

```
