### PR TITLE
add command USER 1001 to dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,6 @@ COPY data/ data/
 # Copy csv generator
 COPY --from=builder /workspace/bin/csv-generator .
 
+USER 1001
+
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
add command USER 1001 to dockerfile to prevent issues while running on vanilla k8s

if the image used does not define a USER ID you will check the following error:"container has runAsNonRoot and image will run as root. This Fix sets the USER command in dockerfile

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
