### PR TITLE
Add permissions to modify-data-object-task service account

### DIFF
--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -21,7 +21,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: pipeline
+    name: modify-data-object-task
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds permissions to modify-data-object-task service account, that are required by example pipelines to run them.

Fixes #

Signed-off-by: Ondrej Pokorny <opokorny@redhat.com>