### PR TITLE
update golang and fedora version in ci-builder dockerfile

### DIFF
--- a/ci-builder/Dockerfile
+++ b/ci-builder/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used in openshift CI
-FROM quay.io/fedora/fedora:latest
+FROM quay.io/fedora/fedora:37
 
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Install dependencies and tools


### PR DESCRIPTION
**What this PR does / why we need it**:
golang was updated to 1.19
fedora was updated to fixed version, to prevent future issues with older releases of tto built on newest fedora.
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
