### PR TITLE
add pipeline serviceaccount to testing windows10 pipeline

### DIFF
--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -17,11 +17,13 @@ metadata:
   namespace: kubevirt-os-images
 roleRef:
   kind: ClusterRole
-  name: windows10-pipelines
+  name: modify-data-object-task
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: modify-data-object-task
+  - kind: ServiceAccount
+    name: pipeline
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
**What this PR does / why we need it**:
add pipeline serviceaccount to testing windows10 pipeline
This will fix the issue when pipeline is created via UI and has Insufficient permissions to create datavolume 


**Release note**:
```
NONE

```
