### PR TITLE
add missing delete template permission to win 10 installer pipeline

### DIFF
--- a/data/tekton-pipelines/okd/windows10-installer.yaml
+++ b/data/tekton-pipelines/okd/windows10-installer.yaml
@@ -48,6 +48,7 @@ rules:
       - create
       - update
       - patch
+      - delete
     apiGroups:
       - template.openshift.io
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
add missing delete template permission to win 10 installer pipeline

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2152094

**Release note**:
```
NONE

```
