### PR TITLE
fix: add new VIRTIO_IMG env varible to operator

### DIFF
--- a/.github/workflows/update-virtio-version.yaml
+++ b/.github/workflows/update-virtio-version.yaml
@@ -1,0 +1,62 @@
+name: Update virtio version
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+jobs:
+  update-virtio-version:
+    name: Update virtio version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for new release of virtio and create PR if necessary
+        run: |
+          # If GITHUB_FORK_USER is changed, a new access token should be set as a repo secret (ACTIONS_TOKEN)
+          GITHUB_FORK_USER=ksimon1
+
+          # Set git configs to sign the commit
+          git config --global user.email "ksimon@redhat.com"
+          git config --global user.name "Kubevirt tekton tasks operator Update Automation"
+
+          # Clone the tekton-tasks-operator repo with a token to allow pushing before creating a PR
+          git clone "https://${GITHUB_FORK_USER}:${{ secrets.ACTIONS_TOKEN }}@github.com/${GITHUB_FORK_USER}/tekton-tasks-operator"
+
+          # Authenticate with gh cli
+          echo "${{ secrets.ACTIONS_TOKEN }}" > token.txt
+          gh auth login --with-token < token.txt
+          rm token.txt
+
+          # Fetch tekton-tasks-operator changes
+          cd tekton-tasks-operator || exit
+          git remote add upstream https://github.com/kubevirt/tekton-tasks-operator
+          git fetch upstream
+          git reset --hard upstream/master
+
+          # Fetch kubevirt version
+          KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+
+          LOCAL_KUBEVIRT_VERSION=$(grep -Po '(?<=virtio-container-disk:)[^"]+' pkg/environment/environment.go)
+
+          if [[ ${LOCAL_KUBEVIRT_VERSION} != ${KUBEVIRT_VERSION} ]]; then
+            sed -i "s/${LOCAL_KUBEVIRT_VERSION}/${KUBEVIRT_VERSION}/g" pkg/environment/environment.go
+
+            PATCH_BRANCH="update-virtio-version-${KUBEVIRT_VERSION}"
+
+            git checkout -b "${PATCH_BRANCH}"
+            git add pkg/environment/environment.go
+            git commit -sm "Update virtio image version to ${KUBEVIRT_VERSION}"
+            git push --set-upstream --force origin "${PATCH_BRANCH}"
+
+            # Create a new PR in the tekton-tasks-operator repo
+            gh pr create --repo kubevirt/tekton-tasks-operator \
+              --base master \
+              --head "${GITHUB_FORK_USER}:${PATCH_BRANCH}" \
+              --title "Update virtio image version to ${KUBEVIRT_VERSION}" \
+              --body "$(cat <<- EOF
+          		Update virtio image version to ${KUBEVIRT_VERSION}
+          		**Release note**:
+          		\`\`\`release-note
+          		Update virtio image version to ${KUBEVIRT_VERSION}
+          		\`\`\`
+          		EOF
+              )"
+          fi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,6 +39,7 @@ spec:
           - name: "MODIFY_VM_TEMPLATE_IMG"
           - name: "WAIT_FOR_VMI_STATUS_IMG"
           - name: "GENERATE_SSH_KEYS_IMG"
+          - name: "VIRTIO_IMG"
           - name: "OPERATOR_NAMESPACE"
             valueFrom:
               fieldRef:

--- a/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
+++ b/data/olm-catalog/tekton-tasks-operator.clusterserviceversion.yaml
@@ -266,6 +266,7 @@ spec:
                 - name: MODIFY_VM_TEMPLATE_IMG
                 - name: WAIT_FOR_VMI_STATUS_IMG
                 - name: GENERATE_SSH_KEYS_IMG
+                - name: VIRTIO_IMG
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -32,6 +32,7 @@ const (
 	DiskVirtSysprepImageKey   = "DISK_VIRT_SYSPREP_IMG"
 	ModifyVMTemplateImageKey  = "MODIFY_VM_TEMPLATE_IMG"
 	WaitForVMISTatusImageKey  = "WAIT_FOR_VMI_STATUS_IMG"
+	VirtioImageKey            = "VIRTIO_IMG"
 	GenerateSSHKeysImageKey   = "GENERATE_SSH_KEYS_IMG"
 
 	DefaultWaitForVMIStatusIMG  = "quay.io/kubevirt/tekton-task-wait-for-vmi-status:" + operands.TektonTasksVersion
@@ -43,6 +44,7 @@ const (
 	DeafultCopyTemplateIMG      = "quay.io/kubevirt/tekton-task-copy-template:" + operands.TektonTasksVersion
 	DeafultCleanupVMIMG         = "quay.io/kubevirt/tekton-task-execute-in-vm:" + operands.TektonTasksVersion
 	GenerateSSHKeysIMG          = "quay.io/kubevirt/tekton-task-generate-ssh-keys:" + operands.TektonTasksVersion
+	DefaultVirtioIMG            = "quay.io/kubevirt/virtio-container-disk:v0.58.0"
 
 	defaultOperatorVersion = "devel"
 )
@@ -90,6 +92,11 @@ func GetCopyTemplateImage() string {
 // GetCleanupVMImage returns cleanup-vm task image url
 func GetCleanupVMImage() string {
 	return EnvOrDefault(CleanupVMImageKey, DeafultCleanupVMIMG)
+}
+
+// GetVirtioImage returns virtio image url
+func GetVirtioImage() string {
+	return EnvOrDefault(VirtioImageKey, DefaultVirtioIMG)
 }
 
 // GetModifyVMTemplateImage returns modify-vm-template task image url

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -119,6 +119,18 @@ var _ = Describe("environments", func() {
 		Expect(res).To(Equal(DefaultWaitForVMIStatusIMG), "WAIT_FOR_VMI_STATUS_IMG should equal")
 	})
 
+	It("should return correct value for VIRTIO_IMG when variable is set", func() {
+		os.Setenv(VirtioImageKey, testURL)
+		res := GetVirtioImage()
+		Expect(res).To(Equal(testURL), "VIRTIO_IMG should equal")
+		os.Unsetenv(VirtioImageKey)
+	})
+
+	It("should return correct value for VIRTIO_IMG when variable is not set", func() {
+		res := GetVirtioImage()
+		Expect(res).To(Equal(DefaultVirtioIMG), "VIRTIO_IMG should equal")
+	})
+
 	It("should return correct value for GENERATE_SSH_KEYS_IMG when variable is set", func() {
 		os.Setenv(GenerateSSHKeysImageKey, testURL)
 		res := GetSSHKeysStatusImage()

--- a/pkg/tekton-pipelines/tekton-pipelines.go
+++ b/pkg/tekton-pipelines/tekton-pipelines.go
@@ -3,11 +3,13 @@ package tekton_pipelines
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/kubevirt/tekton-tasks-operator/pkg/common"
 	"github.com/kubevirt/tekton-tasks-operator/pkg/environment"
 	"github.com/kubevirt/tekton-tasks-operator/pkg/operands"
 	tektonbundle "github.com/kubevirt/tekton-tasks-operator/pkg/tekton-bundle"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -143,6 +145,14 @@ func reconcileTektonPipelinesFuncs(pipelines []pipeline.Pipeline) []common.Recon
 					newPipeline := newRes.(*pipeline.Pipeline)
 					foundPipeline := foundRes.(*pipeline.Pipeline)
 					foundPipeline.Spec = newPipeline.Spec
+					for i, param := range foundPipeline.Spec.Params {
+						if strings.HasPrefix(param.Name, "virtioContainer") {
+							foundPipeline.Spec.Params[i].Default = &v1beta1.ArrayOrString{
+								Type:      v1beta1.ParamTypeString,
+								StringVal: environment.GetVirtioImage(),
+							}
+						}
+					}
 				}).
 				Reconcile()
 		})

--- a/scripts/csv-generator.go
+++ b/scripts/csv-generator.go
@@ -55,6 +55,7 @@ type generatorFlags struct {
 	copyTemplateImage      string
 	cleanupVMImage         string
 	generateSSHKeys        string
+	virtioImage            string
 }
 
 var (
@@ -93,6 +94,7 @@ func init() {
 	rootCmd.Flags().StringVar(&f.copyTemplateImage, "copy-template-image", "", "Link to copy-template-image task image")
 	rootCmd.Flags().StringVar(&f.generateSSHKeys, "generate-ssh-keys", "", "Link to generate-ssh-keys task image")
 	rootCmd.Flags().StringVar(&f.cleanupVMImage, "cleanup-vm-image", "", "Link to cleanup-vm-image task image")
+	rootCmd.Flags().StringVar(&f.virtioImage, "virtio-image", "", "Link to virtio image")
 
 	rootCmd.Flags().BoolVar(&f.removeCerts, "webhook-remove-certs", false, "Remove the webhook certificate volume and mount")
 	rootCmd.Flags().BoolVar(&f.dumpCRDs, "dump-crds", false, "Dump crds to stdout")
@@ -259,6 +261,14 @@ func buildRelatedImages(flags generatorFlags) ([]interface{}, error) {
 		relatedImages = append(relatedImages, relatedImage)
 	}
 
+	if flags.virtioImage != "" {
+		relatedImage, err := buildRelatedImage(flags.virtioImage, "virtio-container")
+		if err != nil {
+			return nil, err
+		}
+		relatedImages = append(relatedImages, relatedImage)
+	}
+
 	return relatedImages, nil
 }
 
@@ -331,6 +341,10 @@ func updateContainerEnvVars(flags generatorFlags, container v1.Container) []v1.E
 		case environment.GenerateSSHKeysImageKey:
 			if flags.generateSSHKeys != "" {
 				envVariable.Value = flags.generateSSHKeys
+			}
+		case environment.VirtioImageKey:
+			if flags.virtioImage != "" {
+				envVariable.Value = flags.virtioImage
 			}
 		}
 

--- a/scripts/csv-generator_test.go
+++ b/scripts/csv-generator_test.go
@@ -30,6 +30,7 @@ var _ = Describe("csv generator", func() {
 		modifyDataObjectImage:  "testDataObjectImage",
 		copyTemplateImage:      "testCopyTemplateImage",
 		cleanupVMImage:         "testCleanupImage",
+		virtioImage:            "testVirtioImage",
 	}
 	envValues := []v1.EnvVar{
 		{Name: environment.OperatorVersionKey},
@@ -41,6 +42,7 @@ var _ = Describe("csv generator", func() {
 		{Name: environment.DiskVirtSysprepImageKey},
 		{Name: environment.ModifyVMTemplateImageKey},
 		{Name: environment.WaitForVMISTatusImageKey},
+		{Name: environment.VirtioImageKey},
 	}
 
 	csv := csvv1.ClusterServiceVersion{
@@ -108,6 +110,9 @@ var _ = Describe("csv generator", func() {
 					}
 					if envVariable.Name == environment.WaitForVMISTatusImageKey {
 						Expect(envVariable.Value).To(Equal(flags.waitForVMIStatusImage))
+					}
+					if envVariable.Name == environment.VirtioImageKey {
+						Expect(envVariable.Value).To(Equal(flags.virtioImage))
 					}
 				}
 				break


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add new VIRTIO_IMG env varible to operator
with this new env variable, we will be able to use newest virtio container img available in example pipelines

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2155796

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
