### PR TITLE
feat: Add windows server 2022 autounattend config map

### DIFF
--- a/data/tekton-pipelines/kubernetes/windows-efi-installer.yaml
+++ b/data/tekton-pipelines/kubernetes/windows-efi-installer.yaml
@@ -155,20 +155,20 @@ data:
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: windows11-installer
+  name: windows-efi-installer
 spec:
   params:
     - name: winImageDownloadURL
-      description: Download URL to Windows 11 installation ISO (English United States x64 version is needed). You can follow https://www.microsoft.com/en-us/software-download/windows10ISO to get one.
+      description: Download URL to Windows 11 or server 2022 installation ISO (English United States x64 version is needed). You can follow https://www.microsoft.com/en-us/software-download/windows11 or https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2022 to get one.
       type: string
     - name: autounattendConfigMapName
-      description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.).
+      description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.). For example windows11-autounattend or windows2022-autounattend. It is possible to provide customize ConfigMaps created by the user too.
       type: string
       default: windows11-autounattend
     - name: virtioContainerDiskName
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       type: string
-      default: quay.io/kubevirt/virtio-container-disk:latest
+      default: quay.io/kubevirt/virtio-container-disk:v0.59.0-rc.0
   tasks:
     - name: create-source-dv
       params:

--- a/data/tekton-pipelines/kubernetes/windows2022-installer-configmaps.yaml
+++ b/data/tekton-pipelines/kubernetes/windows2022-installer-configmaps.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: windows2022-autounattend
+data:
+  autounattend.xml: |
+    <?xml version="1.0" encoding="utf-8"?>
+    <unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+        <servicing>
+            <package action="configure">
+                <assemblyIdentity name="Microsoft-Windows-ServerDatacenterEvalEdition" version="10.0.20348.587" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="" />
+            </package>
+        </servicing>
+        <settings pass="windowsPE">
+            <component language="neutral" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <SetupUILanguage>
+                    <UILanguage>en-US</UILanguage>
+                </SetupUILanguage>
+                <InputLocale>en-US</InputLocale>
+                <SystemLocale>en-US</SystemLocale>
+                <UILanguage>en-US</UILanguage>
+                <UILanguageFallback>en-US</UILanguageFallback>
+                <UserLocale>en-US</UserLocale>
+            </component>
+            <component language="neutral" name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <DriverPaths>
+                    <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                        <Path>E:\amd64\2k22\</Path>
+                    </PathAndCredentials>
+                </DriverPaths>
+            </component>
+            <component language="neutral" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <DiskConfiguration>
+                    <Disk wcm:action="add">
+                        <CreatePartitions>
+                            <CreatePartition wcm:action="add">
+                                <Order>1</Order>
+                                <Type>Primary</Type>
+                                <Size>300</Size>
+                            </CreatePartition>
+                            <CreatePartition wcm:action="add">
+                                <Order>2</Order>
+                                <Type>EFI</Type>
+                                <Size>100</Size>
+                            </CreatePartition>
+                            <CreatePartition wcm:action="add">
+                                <Order>3</Order>
+                                <Type>MSR</Type>
+                                <Size>128</Size>
+                            </CreatePartition>
+                            <CreatePartition wcm:action="add">
+                                <Order>4</Order>
+                                <Type>Primary</Type>
+                                <Extend>true</Extend>
+                            </CreatePartition>
+                        </CreatePartitions>
+                        <ModifyPartitions>
+                            <ModifyPartition wcm:action="add">
+                                <Order>1</Order>
+                                <PartitionID>1</PartitionID>
+                                <Label>WINRE</Label>
+                                <Format>NTFS</Format>
+                                <TypeID>DE94BBA4-06D1-4D40-A16A-BFD50179D6AC</TypeID>
+                            </ModifyPartition>
+                            <ModifyPartition wcm:action="add">
+                                <Order>2</Order>
+                                <PartitionID>2</PartitionID>
+                                <Label>EFI</Label>
+                                <Format>FAT32</Format>
+                            </ModifyPartition>
+                            <ModifyPartition wcm:action="add">
+                                <Order>3</Order>
+                                <PartitionID>3</PartitionID>
+                            </ModifyPartition>
+                            <ModifyPartition wcm:action="add">
+                                <Order>4</Order>
+                                <PartitionID>4</PartitionID>
+                                <Label>Windows</Label>
+                                <Letter>C</Letter>
+                                <Format>NTFS</Format>
+                            </ModifyPartition>
+                        </ModifyPartitions>
+                        <DiskID>0</DiskID>
+                        <WillWipeDisk>true</WillWipeDisk>
+                    </Disk>
+                </DiskConfiguration>
+                <ImageInstall>
+                    <OSImage>
+                        <InstallFrom>
+                            <MetaData wcm:action="add">
+                                <Key>/IMAGE/NAME</Key>
+                                <Value>Windows Server 2022 SERVERDATACENTER</Value>
+                            </MetaData>
+                        </InstallFrom>
+                        <InstallTo>
+                            <DiskID>0</DiskID>
+                            <PartitionID>4</PartitionID>
+                        </InstallTo>
+                    </OSImage>
+                </ImageInstall>
+                <UserData>
+                    <AcceptEula>true</AcceptEula>
+                    <FullName>AdminAccount</FullName>
+                    <Organization>OrgName</Organization>
+                </UserData>
+            </component>
+        </settings>
+        <settings pass="specialize">
+            <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <InputLocale>0409:00000409</InputLocale>
+                <SystemLocale>en-US</SystemLocale>
+                <UILanguage>en-US</UILanguage>
+                <UserLocale>en-US</UserLocale>
+            </component>
+        </settings>
+        <settings pass="oobeSystem">
+            <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <Reseal>
+                    <Mode>Audit</Mode>
+                </Reseal>
+            </component>
+        </settings>
+        <settings pass="auditUser">
+            <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <RunSynchronous>
+                    <RunSynchronousCommand wcm:action="add">
+                        <Order>1</Order>
+                        <Path>PowerShell -ExecutionPolicy Bypass -NoProfile F:\post-install.ps1</Path>
+                        <Description>Run post-install script</Description>
+                    </RunSynchronousCommand>
+                </RunSynchronous>
+                <Generalize>
+                    <ForceShutdownNow>true</ForceShutdownNow>
+                    <Mode>OOBE</Mode>
+                </Generalize>
+            </component>
+        </settings>
+    </unattend>
+  post-install.ps1: |
+    # Install virtio guest drivers
+    # ADDLOCAL is specified to workaround a bug in virtio-win-0.1.217.iso
+    # See:
+    #   - https://github.com/virtio-win/virtio-win-guest-tools-installer/issues/33
+    #   - https://github.com/virtio-win/virtio-win-pkg-scripts/issues/60
+    Start-Process msiexec -Wait -ArgumentList "/i E:\virtio-win-gt-x64.msi /qn /passive /norestart ADDLOCAL=FE_balloon_driver,FE_network_driver,FE_vioinput_driver,FE_viorng_driver,FE_vioscsi_driver,FE_vioserial_driver,FE_viostor_driver,FE_viofs_driver,FE_viogpudo_driver"
+
+    # Install qemu guest agent
+    Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
+
+    # Rename cached unattend.xml to avoid it is picked up by sysprep
+    mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml
+
+    # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
+    (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
+---

--- a/data/tekton-pipelines/okd/windows-customize.yaml
+++ b/data/tekton-pipelines/okd/windows-customize.yaml
@@ -311,7 +311,7 @@ spec:
                   "storage": {
                     "resources": {
                       "requests": {
-                        "storage": "60Gi"
+                        "storage": "20Gi"
                       }
                     }
                   },

--- a/data/tekton-pipelines/okd/windows-efi-installer.yaml
+++ b/data/tekton-pipelines/okd/windows-efi-installer.yaml
@@ -155,7 +155,7 @@ data:
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: windows11-installer
+  name: windows-efi-installer
 spec:
   finally:
     - name: cleanup-vm
@@ -180,14 +180,14 @@ spec:
         kind: ClusterTask
         name: modify-vm-template
   params:
-    - description: Download URL to Windows 11 installation ISO (English United States x64 version is needed). You can follow https://www.microsoft.com/en-us/software-download/windows11 to get one.
+    - description: Download URL to Windows 11 or server 2022 installation ISO (English United States x64 version is needed). You can follow https://www.microsoft.com/en-us/software-download/windows11 or https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2022 to get one.
       name: winImageDownloadURL
       type: string
     - default: windows11-autounattend
-      description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.).
+      description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.). For example windows11-autounattend or windows2022-autounattend. It is possible to provide customize ConfigMaps created by the user too.
       name: autounattendConfigMapName
       type: string
-    - default: quay.io/kubevirt/virtio-container-disk:latest
+    - default: quay.io/kubevirt/virtio-container-disk:v0.59.0-rc.0
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       name: virtioContainerDiskName
       type: string
@@ -200,7 +200,7 @@ spec:
       name: sourceTemplateNamespace
       type: string
     - default: windows11-desktop-large-installer
-      description: Name of the installer Template which is created. A VM created from this template is used to install Windows 11.
+      description: Name of the installer Template which is created. A VM created from this template is used to install Windows 11 or other Windows version.
       name: installerTemplateName
       type: string
     - default: "false"
@@ -257,8 +257,8 @@ spec:
           value: $(tasks.copy-template.results.name)
         - name: templateAnnotations
           value:
-            - "openshift.io/display-name: Microsoft Windows 11 Installer VM"
-            - "description: Template for installing Microsoft Windows 11."
+            - "openshift.io/display-name: Microsoft Windows Installer VM"
+            - "description: Template for installing Microsoft Windows."
         - name: deleteDatavolumeTemplate
           value: "true"
         - name: datavolumeTemplates

--- a/data/tekton-pipelines/okd/windows2022-installer-configmaps.yaml
+++ b/data/tekton-pipelines/okd/windows2022-installer-configmaps.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: windows2022-autounattend
+data:
+  autounattend.xml: |
+    <?xml version="1.0" encoding="utf-8"?>
+    <unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+        <servicing>
+            <package action="configure">
+                <assemblyIdentity name="Microsoft-Windows-ServerDatacenterEvalEdition" version="10.0.20348.587" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="" />
+            </package>
+        </servicing>
+        <settings pass="windowsPE">
+            <component language="neutral" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <SetupUILanguage>
+                    <UILanguage>en-US</UILanguage>
+                </SetupUILanguage>
+                <InputLocale>en-US</InputLocale>
+                <SystemLocale>en-US</SystemLocale>
+                <UILanguage>en-US</UILanguage>
+                <UILanguageFallback>en-US</UILanguageFallback>
+                <UserLocale>en-US</UserLocale>
+            </component>
+            <component language="neutral" name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <DriverPaths>
+                    <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                        <Path>E:\amd64\2k22\</Path>
+                    </PathAndCredentials>
+                </DriverPaths>
+            </component>
+            <component language="neutral" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <DiskConfiguration>
+                    <Disk wcm:action="add">
+                        <CreatePartitions>
+                            <CreatePartition wcm:action="add">
+                                <Order>1</Order>
+                                <Type>Primary</Type>
+                                <Size>300</Size>
+                            </CreatePartition>
+                            <CreatePartition wcm:action="add">
+                                <Order>2</Order>
+                                <Type>EFI</Type>
+                                <Size>100</Size>
+                            </CreatePartition>
+                            <CreatePartition wcm:action="add">
+                                <Order>3</Order>
+                                <Type>MSR</Type>
+                                <Size>128</Size>
+                            </CreatePartition>
+                            <CreatePartition wcm:action="add">
+                                <Order>4</Order>
+                                <Type>Primary</Type>
+                                <Extend>true</Extend>
+                            </CreatePartition>
+                        </CreatePartitions>
+                        <ModifyPartitions>
+                            <ModifyPartition wcm:action="add">
+                                <Order>1</Order>
+                                <PartitionID>1</PartitionID>
+                                <Label>WINRE</Label>
+                                <Format>NTFS</Format>
+                                <TypeID>DE94BBA4-06D1-4D40-A16A-BFD50179D6AC</TypeID>
+                            </ModifyPartition>
+                            <ModifyPartition wcm:action="add">
+                                <Order>2</Order>
+                                <PartitionID>2</PartitionID>
+                                <Label>EFI</Label>
+                                <Format>FAT32</Format>
+                            </ModifyPartition>
+                            <ModifyPartition wcm:action="add">
+                                <Order>3</Order>
+                                <PartitionID>3</PartitionID>
+                            </ModifyPartition>
+                            <ModifyPartition wcm:action="add">
+                                <Order>4</Order>
+                                <PartitionID>4</PartitionID>
+                                <Label>Windows</Label>
+                                <Letter>C</Letter>
+                                <Format>NTFS</Format>
+                            </ModifyPartition>
+                        </ModifyPartitions>
+                        <DiskID>0</DiskID>
+                        <WillWipeDisk>true</WillWipeDisk>
+                    </Disk>
+                </DiskConfiguration>
+                <ImageInstall>
+                    <OSImage>
+                        <InstallFrom>
+                            <MetaData wcm:action="add">
+                                <Key>/IMAGE/NAME</Key>
+                                <Value>Windows Server 2022 SERVERDATACENTER</Value>
+                            </MetaData>
+                        </InstallFrom>
+                        <InstallTo>
+                            <DiskID>0</DiskID>
+                            <PartitionID>4</PartitionID>
+                        </InstallTo>
+                    </OSImage>
+                </ImageInstall>
+                <UserData>
+                    <AcceptEula>true</AcceptEula>
+                    <FullName>AdminAccount</FullName>
+                    <Organization>OrgName</Organization>
+                </UserData>
+            </component>
+        </settings>
+        <settings pass="specialize">
+            <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <InputLocale>0409:00000409</InputLocale>
+                <SystemLocale>en-US</SystemLocale>
+                <UILanguage>en-US</UILanguage>
+                <UserLocale>en-US</UserLocale>
+            </component>
+        </settings>
+        <settings pass="oobeSystem">
+            <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <Reseal>
+                    <Mode>Audit</Mode>
+                </Reseal>
+            </component>
+        </settings>
+        <settings pass="auditUser">
+            <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+                <RunSynchronous>
+                    <RunSynchronousCommand wcm:action="add">
+                        <Order>1</Order>
+                        <Path>PowerShell -ExecutionPolicy Bypass -NoProfile F:\post-install.ps1</Path>
+                        <Description>Run post-install script</Description>
+                    </RunSynchronousCommand>
+                </RunSynchronous>
+                <Generalize>
+                    <ForceShutdownNow>true</ForceShutdownNow>
+                    <Mode>OOBE</Mode>
+                </Generalize>
+            </component>
+        </settings>
+    </unattend>
+  post-install.ps1: |
+    # Install virtio guest drivers
+    # ADDLOCAL is specified to workaround a bug in virtio-win-0.1.217.iso
+    # See:
+    #   - https://github.com/virtio-win/virtio-win-guest-tools-installer/issues/33
+    #   - https://github.com/virtio-win/virtio-win-pkg-scripts/issues/60
+    Start-Process msiexec -Wait -ArgumentList "/i E:\virtio-win-gt-x64.msi /qn /passive /norestart ADDLOCAL=FE_balloon_driver,FE_network_driver,FE_vioinput_driver,FE_viorng_driver,FE_vioscsi_driver,FE_vioserial_driver,FE_viostor_driver,FE_viofs_driver,FE_viogpudo_driver"
+
+    # Install qemu guest agent
+    Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
+
+    # Rename cached unattend.xml to avoid it is picked up by sysprep
+    mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml
+
+    # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
+    (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
+---

--- a/scripts/test-files/windows2022-customize-pipelinerun.yaml
+++ b/scripts/test-files/windows2022-customize-pipelinerun.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: windows2k22-customize-run-
+  labels: 
+    pipelinerun: windows2k22-customize-run
+spec:
+  params:
+    - name: sourceTemplateName
+      value: windows2k22-server-large
+    - name: customizeTemplateName
+      value: windows2k22-desktop-large-customize-sqlserver
+    - name: goldenTemplateName
+      value: windows2k22-desktop-large-golden-sqlserver
+  pipelineRef:
+    name: windows-customize
+  taskRunSpecs:
+    - pipelineTaskName: copy-template-customize
+      taskServiceAccountName: copy-template-task
+    - pipelineTaskName: modify-vm-template-customize
+      taskServiceAccountName: modify-vm-template-task
+    - pipelineTaskName: create-vm-from-template
+      taskServiceAccountName: create-vm-from-template-task
+    - pipelineTaskName: wait-for-vmi-status
+      taskServiceAccountName: wait-for-vmi-status-task
+    - pipelineTaskName: create-base-dv
+      taskServiceAccountName: modify-data-object-task
+    - pipelineTaskName: cleanup-vm
+      taskServiceAccountName: cleanup-vm-task
+    - pipelineTaskName: copy-template-golden
+      taskServiceAccountName: copy-template-task
+    - pipelineTaskName: modify-vm-template-golden
+      taskServiceAccountName: modify-vm-template-task
+status: {}

--- a/scripts/test-files/windows2022-dv.yaml
+++ b/scripts/test-files/windows2022-dv.yaml
@@ -1,0 +1,19 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: "iso-dv"
+  namespace: kubevirt
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+spec:
+  source:
+      registry:
+        url: 'docker://quay.io/openshift-cnv/containerdisks:Win2022_English_x64'
+        secretRef: "tekton-operator-container-disk-puller" 
+  storage:
+    volumeMode: Filesystem
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: "8Gi"

--- a/scripts/test-files/windows2022-installer-pipelinerun.yaml
+++ b/scripts/test-files/windows2022-installer-pipelinerun.yaml
@@ -1,9 +1,9 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  generateName: windows11-installer-run-
+  generateName: windows2k22-installer-run-
   labels:
-    pipelinerun: windows11-installer-run
+    pipelinerun: windows2k22--installer-run
 spec:
   params:
   - name: winImageDownloadURL


### PR DESCRIPTION
**What this PR does / why we need it**:
Add windows server 2022 autounattend config map
This commit adds new configmap for windows server 2022 and renames
windows11-installer pipeline to windows-efi-installer pipeline.
With this change user can install other windows which requires efi +
secure boot with single pipeline.

**Release note**:
```
Add windows server 2022 autounattend config map
```
