### PR TITLE
fix: revert back the hardcoded version of kubevirt for tests

### DIFF
--- a/scripts/deploy-resources.sh
+++ b/scripts/deploy-resources.sh
@@ -6,9 +6,8 @@ if oc get namespace tekton-pipelines > /dev/null 2>&1; then
   exit 0
 fi
 
-KUBEVIRT_VERSION="v0.58.0"
-#$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
-#           jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
 CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: revert back the hardcoded version of kubevirt for tests
fix: remove TSC labels from worker nodes in e2e tests

Latest kubevirt version introduced tsc node selectors for windows vms. This is causing problems during scheduling of windows VM, which are in pending state, due to different tsc labels on nodes. Currently there is no easy fix in kubevirt, because it would break migration flow. Due to that, we have to disable node-labeller and remove the tsc labels from nodes, so virt-controller can schedule the VMs on more nodes. This approach will break migration flow, but in our tests we do not test it.

**Release note**:
```
NONE
```
