### PR TITLE
feat: switch default configmap for windows-customize pipeline

### DIFF
--- a/data/tekton-pipelines/kubernetes/windows-customize-configmaps.yaml
+++ b/data/tekton-pipelines/kubernetes/windows-customize-configmaps.yaml
@@ -39,6 +39,9 @@ data:
       </settings>
     </unattend>
   sqlserver-install.ps1: |
+    #https://github.com/kubevirt/user-guide/pull/645
+    netsh interface ipv4 set subinterface "Ethernet Instance 0" mtu=1200 store=persistent
+
     # Download SQL server
     $url = "https://go.microsoft.com/fwlink/?linkid=866658"
     $setupPath = "C:\SQL2019-SSEI-Expr.exe"
@@ -93,6 +96,9 @@ data:
       </settings>
     </unattend>
   vsCode-install.ps1: |
+    #https://github.com/kubevirt/user-guide/pull/645
+    netsh interface ipv4 set subinterface "Ethernet Instance 0" mtu=1200 store=persistent
+
     # Download VS Code
     $url = "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user"
     $setupPath = "C:\VSCodeUserSetup-x64.exe"

--- a/data/tekton-pipelines/kubernetes/windows-customize-pipeline.yaml
+++ b/data/tekton-pipelines/kubernetes/windows-customize-pipeline.yaml
@@ -16,7 +16,7 @@ spec:
     - name: customizeConfigMapName
       description: Name of the ConfigMap containing the customization and sysprep configuration files (unattend.xml, etc.). For example windows10-sqlserver or windows11-vs-code. It is possible to provide customize ConfigMaps created by the user too.
       type: string
-      default: windows10-sqlserver
+      default: windows10-vs-code
   tasks:
     - name: create-base-dv
       params:

--- a/data/tekton-pipelines/okd/windows-customize-configmaps.yaml
+++ b/data/tekton-pipelines/okd/windows-customize-configmaps.yaml
@@ -39,6 +39,9 @@ data:
       </settings>
     </unattend>
   sqlserver-install.ps1: |
+    #https://github.com/kubevirt/user-guide/pull/645
+    netsh interface ipv4 set subinterface "Ethernet Instance 0" mtu=1200 store=persistent
+
     # Download SQL server
     $url = "https://go.microsoft.com/fwlink/?linkid=866658"
     $setupPath = "C:\SQL2019-SSEI-Expr.exe"
@@ -93,6 +96,9 @@ data:
       </settings>
     </unattend>
   vsCode-install.ps1: |
+    #https://github.com/kubevirt/user-guide/pull/645
+    netsh interface ipv4 set subinterface "Ethernet Instance 0" mtu=1200 store=persistent
+
     # Download VS Code
     $url = "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user"
     $setupPath = "C:\VSCodeUserSetup-x64.exe"

--- a/data/tekton-pipelines/okd/windows-customize-pipeline.yaml
+++ b/data/tekton-pipelines/okd/windows-customize-pipeline.yaml
@@ -18,11 +18,11 @@ spec:
     - name: customizeConfigMapName
       description: Name of the ConfigMap containing the customization and sysprep configuration files (unattend.xml, etc.). For example windows10-sqlserver or windows11-vs-code. It is possible to provide customize ConfigMaps created by the user too.
       type: string
-      default: windows-sqlserver
+      default: windows-vs-code
     - name: customizeTemplateName
       description: Name of the customize Template which is created. A VM created from this template is used to customize Windows.
       type: string
-      default: windows10-desktop-large-customize-sqlserver
+      default: windows10-desktop-large-customize-vs-code
     - name: allowReplaceCustomizationTemplate
       description: Allow to replace an already existing customize Template.
       type: string
@@ -30,7 +30,7 @@ spec:
     - name: goldenTemplateName
       description: Name of the golden Template which is created. Pre-installed Windows VMs can be created from this template.
       type: string
-      default: windows10-desktop-large-golden-sqlserver
+      default: windows10-desktop-large-golden-vs-code
     - name: allowReplaceGoldenTemplate
       description: Allow to replace an already existing golden Template.
       type: string

--- a/scripts/test-files/windows2k22-customize-pipelinerun.yaml
+++ b/scripts/test-files/windows2k22-customize-pipelinerun.yaml
@@ -12,6 +12,8 @@ spec:
       value: windows2k22-desktop-large-customize-sqlserver
     - name: goldenTemplateName
       value: windows2k22-desktop-large-golden-sqlserver
+    - name: customizeConfigMapName
+      value: windows-sqlserver
   pipelineRef:
     name: windows-customize
   taskRunSpecs:


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: switch default configmap for windows-customize pipeline
This PR switch default configmap for windows-customize pipeline from windows-sqlserver to windows-vs-code. This change is done, because it makes more sense to install vs-code to windows10/11 than sql server. The windows 2k22 can still use vs-code or sql server config map

**Release note**:
```
switch default configmap (from sql server to vs code) for windows-customize pipeline
```
