### PR TITLE
fix: wrong modify-data-object env variable name

### DIFF
--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -26,7 +26,7 @@ const (
 	OperatorNamespaceKey      = "OPERATOR_NAMESPACE"
 	CleanupVMImageKey         = "CLEANUP_VM_IMG"
 	CopyTemplateImageKey      = "COPY_TEMPLATE_IMG"
-	ModifyDataObjectImageKey  = "MODIFY_DATAOBJECT_IMG"
+	ModifyDataObjectImageKey  = "MODIFY_DATA_OBJECT_IMG"
 	CreateVMImageKey          = "CREATE_VM_IMG"
 	DiskVirtCustomizeImageKey = "DISK_VIRT_CUSTOMIZE_IMG"
 	DiskVirtSysprepImageKey   = "DISK_VIRT_SYSPREP_IMG"

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -47,16 +47,16 @@ var _ = Describe("environments", func() {
 		Expect(res).To(Equal(DeafultCopyTemplateIMG), "COPY_TEMPLATE_IMG should equal")
 	})
 
-	It("should return correct value for MODIFY_DATAOBJECT_IMG when variable is set", func() {
+	It("should return correct value for MODIFY_DATA_OBJECT_IMG when variable is set", func() {
 		os.Setenv(ModifyDataObjectImageKey, testURL)
 		res := GetModifyDataObjectImage()
-		Expect(res).To(Equal(testURL), "MODIFY_DATAOBJECT_IMG should equal")
+		Expect(res).To(Equal(testURL), "MODIFY_DATA_OBJECT_IMG should equal")
 		os.Unsetenv(ModifyDataObjectImageKey)
 	})
 
-	It("should return correct value for MODIFY_DATAOBJECT_IMG when variable is not set", func() {
+	It("should return correct value for MODIFY_DATA_OBJECT_IMG when variable is not set", func() {
 		res := GetModifyDataObjectImage()
-		Expect(res).To(Equal(DeafultModifyDataObjectIMG), "MODIFY_DATAOBJECT_IMG should equal")
+		Expect(res).To(Equal(DeafultModifyDataObjectIMG), "MODIFY_DATA_OBJECT_IMG should equal")
 	})
 
 	It("should return correct value for CREATE_VM_IMG when variable is set", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: wrong modify-data-object env variable name
This PR fixes wrong MODIFY_DATAOBJECT_IMG env variable name with correct MODIFY_DATA_OBJECT_IMG.

**Release note**:
```
fix: wrong modify-data-object env variable name
```
