### PR TITLE
[WIP] fix: allow VMs migration during pipelineRun

### DIFF
--- a/data/tekton-pipelines/okd/windows-efi-installer-pipeline.yaml
+++ b/data/tekton-pipelines/okd/windows-efi-installer-pipeline.yaml
@@ -258,9 +258,8 @@ spec:
               source:
                 http:
                   url: "$(params.winImageDownloadURL)"
-              pvc:
-                accessModes:
-                  - ReadWriteOnce
+              storage:
+                volumeMode: "Filesystem"
                 resources:
                   requests:
                     storage: 9Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allow VMs migration during pipelineRun
When something happened to e.g. node during pipelineRun, VM was unable to migrate due to wrong accessMode of source datavolume. This commit changes it, so VMI can be migrated.

**Release note**:
```
fix: allow VMs migration during pipelineRun
```
