### PR TITLE
fix: change name of ipv4 subinterface

### DIFF
--- a/data/tekton-pipelines/okd/windows-customize-configmaps.yaml
+++ b/data/tekton-pipelines/okd/windows-customize-configmaps.yaml
@@ -40,7 +40,7 @@ data:
     </unattend>
   sqlserver-install.ps1: |
     #https://github.com/kubevirt/user-guide/pull/645
-    netsh interface ipv4 set subinterface "Ethernet Instance 0" mtu=1200 store=persistent
+    Set-NetIPInterface -InterfaceIndex $(Get-NetAdapter).ifIndex -NlMtuBytes 1300
 
     # Download SQL server
     $url = "https://go.microsoft.com/fwlink/?linkid=866658"
@@ -97,7 +97,7 @@ data:
     </unattend>
   vsCode-install.ps1: |
     #https://github.com/kubevirt/user-guide/pull/645
-    netsh interface ipv4 set subinterface "Ethernet Instance 0" mtu=1200 store=persistent
+    Set-NetIPInterface -InterfaceIndex $(Get-NetAdapter).ifIndex -NlMtuBytes 1300
 
     # Download VS Code
     $url = "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: change name of ipv4 subinterface
It looks like qemu changes ipv4 subinterface across versions (e.g.
https://forum.proxmox.com/threads/no-network-adapter-in-fresh-windows-server-after-upgrade-to-proxmox-7.92094/page-2#post-404218).
This PR updates name of ipv4 subinterface to be retrieved automatically
from available subinterfaces.

**Release note**:
```
NONE
```
