### PR TITLE
fix: add GVLK key to windows server 2k22 autounattend.xml file

### DIFF
--- a/data/tekton-pipelines/okd/windows-efi-installer-configmaps.yaml
+++ b/data/tekton-pipelines/okd/windows-efi-installer-configmaps.yaml
@@ -257,6 +257,9 @@ data:
                     <AcceptEula>true</AcceptEula>
                     <FullName>AdminAccount</FullName>
                     <Organization>OrgName</Organization>
+                    <ProductKey>
+                        <Key>WX4NM-KYWYW-QJJR4-XV3QB-6VM33</Key>
+                    </ProductKey>
                 </UserData>
             </component>
         </settings>


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add GVLK key to windows server 2k22 autounattend.xml file

This PR adds a generic GVLK to windows server 2k22 autounattend.xml file. This change will prevent a case, when setup will require a product key in autountattend xml file (some isos fails the installation with
windows cannot read <ProductKey> settings from the unattend answer file error).
https://learn.microsoft.com/en-us/windows-server/get-started/kms-client-activation-keys#windows-server-2022

**Release note**:
```
NONE
```
